### PR TITLE
Disable iOS API for sync project

### DIFF
--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -14,8 +14,8 @@ android.libraryVariants.all {
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
-        fromPreset(presets.iosX64, 'iosX64')
-        fromPreset(presets.iosArm64, 'iosArm64')
+//        fromPreset(presets.iosX64, 'iosX64')
+//        fromPreset(presets.iosArm64, 'iosArm64')
 
     }
     sourceSets {
@@ -50,38 +50,38 @@ kotlin {
                 implementation Dep.Test.slf4j
             }
         }
-        iOSMain {
-            final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
-            if (mode == "RELEASE") {
-                kotlin.srcDirs += "src/iosMain/kotlinRelease"
-            } else {
-                kotlin.srcDirs += "src/iosMain/kotlinDebug"
-            }
-            dependsOn commonMain
-            dependencies {
-                implementation Dep.Kotlin.coroutinesNative
-                implementation Dep.Ktor.clientIos
-                implementation Dep.Ktor.jsonNative
-                implementation Dep.Ktor.serializationNative
-                implementation Dep.Kotlin.serializationIos
-            }
-        }
-        configure(iosX64Main) {
-            dependsOn iOSMain
-            dependencies {
-                implementation Dep.Ktor.clientIosX64
-                implementation Dep.Ktor.jsonIosIosX64
-                implementation Dep.Ktor.serializationIosX64
-            }
-        }
-        configure(iosArm64Main) {
-            dependsOn iOSMain
-            dependencies {
-                implementation Dep.Ktor.clientIosArm64
-                implementation Dep.Ktor.jsonIosArm64
-                implementation Dep.Ktor.serializationIosArm64
-            }
-        }
+//        iOSMain {
+//            final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
+//            if (mode == "RELEASE") {
+//                kotlin.srcDirs += "src/iosMain/kotlinRelease"
+//            } else {
+//                kotlin.srcDirs += "src/iosMain/kotlinDebug"
+//            }
+//            dependsOn commonMain
+//            dependencies {
+//                implementation Dep.Kotlin.coroutinesNative
+//                implementation Dep.Ktor.clientIos
+//                implementation Dep.Ktor.jsonNative
+//                implementation Dep.Ktor.serializationNative
+//                implementation Dep.Kotlin.serializationIos
+//            }
+//        }
+//        configure(iosX64Main) {
+//            dependsOn iOSMain
+//            dependencies {
+//                implementation Dep.Ktor.clientIosX64
+//                implementation Dep.Ktor.jsonIosIosX64
+//                implementation Dep.Ktor.serializationIosX64
+//            }
+//        }
+//        configure(iosArm64Main) {
+//            dependsOn iOSMain
+//            dependencies {
+//                implementation Dep.Ktor.clientIosArm64
+//                implementation Dep.Ktor.jsonIosArm64
+//                implementation Dep.Ktor.serializationIosArm64
+//            }
+//        }
     }
 }
 


### PR DESCRIPTION
I don't know why..🤔🤔🤔 

```
2019-12-04 09:43:32,609 [  43910]   WARN - e.project.sync.GradleSyncState - Gradle sync failed: java.lang.AssertionError: Already disposed: file:///Users/takahirom/git/droidkaigi-2020/data/api/src/iosMain/kotlin (31 s 180 ms) 
2019-12-04 09:43:32,609 [  43910]   WARN - e.project.sync.GradleSyncState - java.lang.AssertionError: Already disposed: file:///Users/takahirom/git/droidkaigi-2020/data/api/src/iosMain/kotlin 
java.lang.RuntimeException: java.lang.AssertionError: Already disposed: file:///Users/takahirom/git/droidkaigi-2020/data/api/src/iosMain/kotlin
	at com.intellij.openapi.application.impl.LaterInvocator.invokeAndWait(LaterInvocator.java:175)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:638)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:643)
	at com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.executeOnEdt(ExternalSystemApiUtil.java:367)
	at com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.executeProjectChangeAction(ExternalSystemApiUtil.java:356)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.commit(ProjectDataManagerImpl.java:432)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:162)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:239)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl.importData(ProjectDataManagerImpl.java:246)
	at com.android.tools.idea.gradle.project.sync.idea.IdeaSyncPopulateProjectTask.populateProject(IdeaSyncPopulateProjectTask.java:66)
	at com.android.tools.idea.gradle.project.sync.idea.ProjectSetUpTask.doPopulateProject(ProjectSetUpTask.java:96)
	at com.android.tools.idea.gradle.project.sync.idea.ProjectSetUpTask.onSuccess(ProjectSetUpTask.java:66)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$3.executeImpl(ExternalSystemUtil.java:556)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$3.lambda$execute$0(ExternalSystemUtil.java:388)
	at com.intellij.openapi.project.DumbServiceImpl.suspendIndexingAndRun(DumbServiceImpl.java:149)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$3.execute(ExternalSystemUtil.java:388)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$5.run(ExternalSystemUtil.java:649)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:894)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:169)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:591)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:537)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:59)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:156)
	at com.intellij.openapi.progress.impl.CoreProgressManager$4.run(CoreProgressManager.java:408)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:294)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.AssertionError: Already disposed: file:///Users/takahirom/git/droidkaigi-2020/data/api/src/iosMain/kotlin
	at com.intellij.openapi.roots.impl.SourceFolderImpl.cloneFolder(SourceFolderImpl.java:104)
	at com.intellij.openapi.roots.impl.ContentEntryImpl.cloneEntry(ContentEntryImpl.java:381)
	at com.intellij.openapi.roots.impl.RootModelImpl.docommit(RootModelImpl.java:397)
	at com.intellij.openapi.roots.impl.ModuleRootManagerImpl.doCommit(ModuleRootManagerImpl.java:181)
	at com.intellij.openapi.roots.impl.ModifiableModelCommitter.lambda$multiCommit$0(ModifiableModelCommitter.java:37)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.lambda$commitModel$5(ModuleManagerImpl.java:1008)
	at com.intellij.openapi.roots.impl.ProjectRootManagerImpl.makeRootsChange(ProjectRootManagerImpl.java:332)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.commitModel(ModuleManagerImpl.java:993)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.access$1500(ModuleManagerImpl.java:64)
	at com.intellij.openapi.module.impl.ModuleManagerImpl$ModuleModelImpl.commitWithRunnable(ModuleManagerImpl.java:901)
	at com.intellij.openapi.module.impl.ModuleManagerImpl$ModuleModelImpl.access$1200(ModuleManagerImpl.java:665)
	at com.intellij.openapi.module.impl.ModuleManagerImpl.commitModelWithRunnable(ModuleManagerImpl.java:656)
	at com.intellij.openapi.roots.impl.ModifiableModelCommitter.multiCommit(ModifiableModelCommitter.java:35)
	at com.intellij.openapi.roots.impl.ModifiableModelCommitter.multiCommit(ModifiableModelCommitter.java:24)
	at com.intellij.openapi.externalSystem.service.project.AbstractIdeModifiableModelsProvider.lambda$commit$4(AbstractIdeModifiableModelsProvider.java:340)
	at com.intellij.openapi.roots.impl.ProjectRootManagerImpl.mergeRootsChangesDuring(ProjectRootManagerImpl.java:297)
	at com.intellij.openapi.externalSystem.service.project.AbstractIdeModifiableModelsProvider.commit(AbstractIdeModifiableModelsProvider.java:315)
	at com.intellij.openapi.externalSystem.service.project.manage.ProjectDataManagerImpl$3.execute(ProjectDataManagerImpl.java:436)
	at com.intellij.openapi.externalSystem.util.DisposeAwareProjectChange.run(DisposeAwareProjectChange.java:22)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:994)
	at com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.lambda$executeProjectChangeAction$4(ExternalSystemApiUtil.java:356)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:312)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:152)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:433)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:416)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:399)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:764)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:734)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:824)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:773)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:412)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:411)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```