### PR TITLE
Fix slow first launch

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -27,10 +27,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
 import dagger.android.support.DaggerAppCompatActivity
+import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.announcement.ui.AnnouncementFragment
 import io.github.droidkaigi.confsched2020.announcement.ui.AnnouncementFragment.AnnouncementFragmentModule
 import io.github.droidkaigi.confsched2020.announcement.ui.di.AnnouncementAssistedInjectModule
-import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2020.databinding.ActivityMainBinding
 import io.github.droidkaigi.confsched2020.di.PageScope
@@ -51,7 +51,7 @@ import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.ui.PageConfiguration
 import io.github.droidkaigi.confsched2020.ui.widget.SystemUiManager
 import timber.log.Timber
-import timber.log.debug
+import timber.log.warn
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -93,7 +93,7 @@ class MainActivity : DaggerAppCompatActivity() {
         }
 
         systemViewModel.errorLiveData.observe(this) { appError ->
-            Timber.debug(appError) { "AppError occured" }
+            Timber.warn(appError) { "AppError occured" }
             Snackbar
                 .make(
                     findViewById(R.id.root_nav_host_fragment),

--- a/data/firestore/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/firestore/Firestore.kt
+++ b/data/firestore/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/firestore/Firestore.kt
@@ -4,6 +4,6 @@ import io.github.droidkaigi.confsched2020.model.SessionId
 import kotlinx.coroutines.flow.Flow
 
 interface Firestore {
-    suspend fun getFavoriteSessionIds(): Flow<List<String>>
+    fun getFavoriteSessionIds(): Flow<List<String>>
     suspend fun toggleFavorite(sessionId: SessionId)
 }

--- a/data/repository/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/repository/SessionRepository.kt
+++ b/data/repository/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/repository/SessionRepository.kt
@@ -7,7 +7,7 @@ import io.github.droidkaigi.confsched2020.model.SpeechSession
 import kotlinx.coroutines.flow.Flow
 
 interface SessionRepository {
-    suspend fun sessionContents(): Flow<SessionContents>
+    fun sessionContents(): Flow<SessionContents>
     suspend fun refresh()
     suspend fun toggleFavorite(session: Session, timeout: Long = 3000L)
     suspend fun sessionFeedback(sessionId: String): SessionFeedback

--- a/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/DataSessionRepository.kt
+++ b/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/DataSessionRepository.kt
@@ -15,7 +15,6 @@ import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SessionContents
 import io.github.droidkaigi.confsched2020.model.SessionFeedback
 import io.github.droidkaigi.confsched2020.model.SpeechSession
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
@@ -33,12 +32,12 @@ class DataSessionRepository @Inject constructor(
     private val firestore: Firestore
 ) : SessionRepository {
 
-    override suspend fun sessionContents(): Flow<SessionContents> = coroutineScope {
+    override fun sessionContents(): Flow<SessionContents> {
         val sessionsFlow = sessions()
             .map {
                 it.sortedBy { it.startTime }
             }
-        sessionsFlow.map { sessions ->
+        return sessionsFlow.map { sessions ->
             val speechSessions = sessions.filterIsInstance<SpeechSession>()
             SessionContents(
                 sessions = sessions,
@@ -52,7 +51,7 @@ class DataSessionRepository @Inject constructor(
         }
     }
 
-    private suspend fun sessions(): Flow<List<Session>> {
+    private fun sessions(): Flow<List<Session>> {
         val sessionsFlow = sessionDatabase.sessions()
             .filter { it.isNotEmpty() }
             .onEach { Timber.debug { "sessionDatabase.sessions" } }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
@@ -40,7 +40,7 @@ class SessionsViewModel @Inject constructor(
         val allFilters: Filters
     ) {
         companion object {
-            val EMPTY = UiModel(false, null, mapOf(), listOf(), Filters(), Filters())
+            val EMPTY = UiModel(true, null, mapOf(), listOf(), Filters(), Filters())
         }
     }
 


### PR DESCRIPTION
# Overview
I removed using the suspend function and using flow. It will slow when the first launch. (Currently, refresh() is not called until after authentication.)