### PR TITLE
Updated material-component

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -45,7 +45,7 @@ object Dep {
         val recyclerView = "androidx.recyclerview:recyclerview:1.0.0"
         val constraint = "androidx.constraintlayout:constraintlayout:2.0.0-beta2"
         val emoji = "androidx.emoji:emoji-appcompat:1.0.0"
-        val design = "com.google.android.material:material:1.1.0-beta01"
+        val design = "com.google.android.material:material:1.1.0-rc01"
         val coreKtx = "androidx.core:core-ktx:1.2.0-alpha03"
         val preference = "androidx.preference:preference:1.1.0-rc01"
         val browser = "androidx.browser:browser:1.0.0"


### PR DESCRIPTION
## Overview
Updated material-components library.  

Because the fix for [this issue](https://github.com/material-components/material-components-android/issues/514)  is included in [beta02](https://github.com/material-components/material-components-android/releases/tag/1.1.0-beta02) or higher.  
(The survey button is the place in this app.)

|beta01|rc01|
|:--:|:--:|
| ![device-2019-12-29-233821](https://user-images.githubusercontent.com/13705006/71558338-76cf1d00-2a95-11ea-8126-5e09ba258b2d.png) | ![device-2019-12-29-234244](https://user-images.githubusercontent.com/13705006/71558341-83ec0c00-2a95-11ea-8fdf-7660ad9d7912.png) |