### PR TITLE
Use centerInside for sponsor image

### DIFF
--- a/feature/sponsor/src/main/res/layout/item_sponsor.xml
+++ b/feature/sponsor/src/main/res/layout/item_sponsor.xml
@@ -15,6 +15,7 @@
             android:layout_height="36dp"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
+            android:scaleType="centerInside"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             />


### PR DESCRIPTION
## Overview (Required)
- The design hasn't been fixed yet, but it seems better to see the entire image.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
