### PR TITLE
Added dependency on LeakCanary

### DIFF
--- a/android-base/build.gradle
+++ b/android-base/build.gradle
@@ -111,6 +111,7 @@ dependencies {
         debugImplementation it
     }
     debugImplementation Dep.Stetho.stetho
+    debugImplementation Dep.LeakCanary.leakCanary
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -168,10 +168,8 @@ object Dep {
     val liveEvent = "com.github.hadilq.liveevent:liveevent:1.0.1"
 
     object LeakCanary {
-        val version = "1.6.3"
+        val version = "2.1"
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:$version"
-        val leakCanaryNoOp = "com.squareup.leakcanary:leakcanary-android-no-op:$version"
-        val leakCanaryFragment = "com.squareup.leakcanary:leakcanary-support-fragment:$version"
     }
 
     object Stetho {


### PR DESCRIPTION
## Issue
- close #149

## Overview (Required)

- Update to LeakCanary 2.1.
  - [Upgrading to LeakCanary 2 - LeakCanary](https://square.github.io/leakcanary/upgrading-to-leakcanary-2.0/)
- Added dependency on LeakCanary for only debug build.