### PR TITLE
add autoLink attribute in session detail

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -169,6 +169,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="22dp"
+                    android:autoLink="web"
                     android:text="@{session.desc}"
                     android:textAppearance="?textAppearanceBody1"
                     android:textColor="?android:attr/textColorPrimary"


### PR DESCRIPTION
## Issue
- close #181 
## Overview (Required)
- add autoLink attribute in session detail

## Links
- https://github.com/DroidKaigi/conference-app-2020/blob/b6a92c302839309a53538807214aa7c967f96112/feature/session/src/main/res/layout/fragment_speaker.xml#L114

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8677433/72355487-eea27600-372a-11ea-925b-e1843c804ec9.png" width="300" /> | <img src=https://user-images.githubusercontent.com/8677433/72355376-adaa6180-372a-11ea-9837-fc891a4121e4.png width="300"/>