### PR TITLE
Migrate Dagger component builder to factory pattern

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/ApiComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/ApiComponentModule.kt
@@ -14,9 +14,8 @@ object ApiComponentModule {
     @Provides
     @Singleton
     fun provideDroidKaigiApi(application: Application): DroidKaigiApi {
-        return ApiComponent.builder()
-            .context(application)
-            .build()
+        return ApiComponent.factory()
+            .create(application)
             .DroidKaigiApi()
     }
 
@@ -24,9 +23,8 @@ object ApiComponentModule {
     @Provides
     @Singleton
     fun provideGoogleFormApi(application: Application): GoogleFormApi {
-        return ApiComponent.builder()
-            .context(application)
-            .build()
+        return ApiComponent.factory()
+            .create(application)
             .GoogleFormApi()
     }
 }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppComponent.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppComponent.kt
@@ -26,11 +26,9 @@ import javax.inject.Singleton
     ]
 )
 interface AppComponent : AndroidInjector<App>, AppComponentInterface {
-    @Component.Builder
-    interface Builder {
-        @BindsInstance fun application(application: Application): Builder
-
-        fun build(): AppComponent
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance application: Application): AppComponent
     }
 
     override fun inject(app: App)
@@ -40,6 +38,4 @@ interface AppComponent : AndroidInjector<App>, AppComponentInterface {
     fun contributorRepository(): ContributorRepository
 }
 
-fun Application.createAppComponent() = DaggerAppComponent.builder()
-    .application(this)
-    .build()
+fun Application.createAppComponent() = DaggerAppComponent.factory().create(this)

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DbComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DbComponentModule.kt
@@ -17,56 +17,40 @@ object DbComponentModule {
     @JvmStatic @Provides @Singleton fun provideItemStore(
         application: Application
     ): SessionDatabase {
-        return DbComponent.builder()
-            .context(application)
-            .coroutineContext(Dispatchers.IO)
-            .filename("droidkaigi.db")
-            .build()
+        return DbComponent.factory()
+            .create(application, Dispatchers.IO, "droidkaigi.db")
             .sessionDatabase()
     }
 
     @JvmStatic @Provides @Singleton fun provideSponsorStore(
         application: Application
     ): SponsorDatabase {
-        return DbComponent.builder()
-            .context(application)
-            .coroutineContext(Dispatchers.IO)
-            .filename("droidkaigi.db")
-            .build()
+        return DbComponent.factory()
+            .create(application, Dispatchers.IO, "droidkaigi.db")
             .sponsorDatabase()
     }
 
     @JvmStatic @Provides @Singleton fun provideAnnouncementStore(
         application: Application
     ): AnnouncementDatabase {
-        return DbComponent.builder()
-            .context(application)
-            .coroutineContext(Dispatchers.IO)
-            .filename("droidkaigi.db")
-            .build()
+        return DbComponent.factory()
+            .create(application, Dispatchers.IO, "droidkaigi.db")
             .announcementDatabase()
     }
 
     @JvmStatic @Provides @Singleton fun provideStaffStore(
         application: Application
     ): StaffDatabase {
-        return DbComponent.builder()
-            .context(application)
-            .coroutineContext(Dispatchers.IO)
-            .filename("droidkaigi.db")
-            .build()
+        return DbComponent.factory()
+            .create(application, Dispatchers.IO, "droidkaigi.db")
             .staffDatabase()
     }
 
     @JvmStatic @Provides @Singleton fun provideContributorStore(
         application: Application
     ): ContributorDatabase {
-        return DbComponent
-            .builder()
-            .context(application)
-            .coroutineContext(Dispatchers.IO)
-            .filename("droidkaigi.db")
-            .build()
+        return DbComponent.factory()
+            .create(application, Dispatchers.IO, "droidkaigi.db")
             .contributorDatabase()
     }
 }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DeviceComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DeviceComponentModule.kt
@@ -11,9 +11,8 @@ import javax.inject.Singleton
 object DeviceComponentModule {
     @JvmStatic @Provides @Singleton
     fun provideWifiManager(application: Application): WifiManager {
-        return DeviceComponent.builder()
-            .context(application)
-            .build()
+        return DeviceComponent.factory()
+            .create(application)
             .WifiManager()
     }
 }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/FirestoreComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/FirestoreComponentModule.kt
@@ -10,9 +10,8 @@ import javax.inject.Singleton
 @Module
 object FirestoreComponentModule {
     @JvmStatic @Provides @Singleton fun provideRepository(): Firestore {
-        return FirestoreComponent.builder()
-            .coroutineContext(Dispatchers.IO)
-            .build()
+        return FirestoreComponent.factory()
+            .create(Dispatchers.IO)
             .firestore()
     }
 }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
@@ -64,15 +64,15 @@ object RepositoryComponentModule {
     ): RepositoryComponent {
         return RepositoryComponent.factory()
             .create(
-                context,
-                droidKaigiApi,
-                googleFormApi,
-                sessionDatabase,
-                sponsorDatabase,
-                announcementDatabase,
-                staffDatabase,
-                contributorDatabase,
-                firestore
+                context = context,
+                droidKaigiApi = droidKaigiApi,
+                googleFormApi = googleFormApi,
+                sessionDatabase = sessionDatabase,
+                sponsorDatabase = sponsorDatabase,
+                announcementDatabase = announcementDatabase,
+                staffDatabase = staffDatabase,
+                contributorDatabase = contributorDatabase,
+                firestore = firestore
             )
     }
 }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
@@ -55,23 +55,24 @@ object RepositoryComponentModule {
         context: Context,
         droidKaigiApi: DroidKaigiApi,
         googleFormApi: GoogleFormApi,
-        database: SessionDatabase,
+        sessionDatabase: SessionDatabase,
         sponsorDatabase: SponsorDatabase,
         announcementDatabase: AnnouncementDatabase,
         staffDatabase: StaffDatabase,
         contributorDatabase: ContributorDatabase,
         firestore: Firestore
     ): RepositoryComponent {
-        return RepositoryComponent.builder()
-            .context(context)
-            .droidKaigiApi(droidKaigiApi)
-            .googleFormApi(googleFormApi)
-            .database(database)
-            .sponsorDatabase(sponsorDatabase)
-            .firestore(firestore)
-            .announcementDatabase(announcementDatabase)
-            .staffDatabase(staffDatabase)
-            .contributorDatabase(contributorDatabase)
-            .build()
+        return RepositoryComponent.factory()
+            .create(
+                context,
+                droidKaigiApi,
+                googleFormApi,
+                sessionDatabase,
+                sponsorDatabase,
+                announcementDatabase,
+                staffDatabase,
+                contributorDatabase,
+                firestore
+            )
     }
 }

--- a/data/api/src/main/java/io/github/droidkaigi/confsched2020/data/api/ApiComponent.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/confsched2020/data/api/ApiComponent.kt
@@ -16,14 +16,12 @@ interface ApiComponent {
     fun DroidKaigiApi(): DroidKaigiApi
     fun GoogleFormApi(): GoogleFormApi
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance fun context(context: Context): Builder
-
-        fun build(): ApiComponent
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance context: Context): ApiComponent
     }
 
     companion object {
-        fun builder(): Builder = DaggerApiComponent.builder()
+        fun factory(): Factory = DaggerApiComponent.factory()
     }
 }

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/DbComponent.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/DbComponent.kt
@@ -20,18 +20,16 @@ interface DbComponent {
     fun staffDatabase(): StaffDatabase
     fun contributorDatabase(): ContributorDatabase
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance fun context(context: Context): Builder
-
-        @BindsInstance fun coroutineContext(coroutineContext: CoroutineContext): Builder
-
-        @BindsInstance fun filename(filename: String?): Builder
-
-        fun build(): DbComponent
+    @Component.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance context: Context,
+            @BindsInstance coroutineContext: CoroutineContext,
+            @BindsInstance filename: String?
+        ): DbComponent
     }
 
     companion object {
-        fun builder(): Builder = DaggerDbComponent.builder()
+        fun factory(): Factory = DaggerDbComponent.factory()
     }
 }

--- a/data/device/src/main/java/io/github/droidkaigi/confsched2020/data/device/DeviceComponent.kt
+++ b/data/device/src/main/java/io/github/droidkaigi/confsched2020/data/device/DeviceComponent.kt
@@ -15,14 +15,12 @@ import javax.inject.Singleton
 interface DeviceComponent {
     fun WifiManager(): WifiManager
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance fun context(context: Context): Builder
-
-        fun build(): DeviceComponent
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance context: Context): DeviceComponent
     }
 
     companion object {
-        fun builder(): Builder = DaggerDeviceComponent.builder()
+        fun factory(): Factory = DaggerDeviceComponent.factory()
     }
 }

--- a/data/firestore/src/main/java/io/github/droidkaigi/confsched2020/data/firestore/FirestoreComponent.kt
+++ b/data/firestore/src/main/java/io/github/droidkaigi/confsched2020/data/firestore/FirestoreComponent.kt
@@ -15,15 +15,12 @@ import kotlin.coroutines.CoroutineContext
 interface FirestoreComponent {
     fun firestore(): Firestore
 
-    @Component.Builder
-    interface Builder {
-
-        @BindsInstance fun coroutineContext(coroutineContext: CoroutineContext): Builder
-
-        fun build(): FirestoreComponent
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance coroutineContext: CoroutineContext): FirestoreComponent
     }
 
     companion object {
-        fun builder(): Builder = DaggerFirestoreComponent.builder()
+        fun factory(): Factory = DaggerFirestoreComponent.factory()
     }
 }

--- a/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/RepositoryComponent.kt
+++ b/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/RepositoryComponent.kt
@@ -32,22 +32,22 @@ interface RepositoryComponent {
     fun staffRepository(): StaffRepository
     fun contributorRepository(): ContributorRepository
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance fun context(context: Context): Builder
-        @BindsInstance fun droidKaigiApi(api: DroidKaigiApi): Builder
-        @BindsInstance fun googleFormApi(api: GoogleFormApi): Builder
-        @BindsInstance fun database(database: SessionDatabase): Builder
-        @BindsInstance fun sponsorDatabase(database: SponsorDatabase): Builder
-        @BindsInstance fun announcementDatabase(database: AnnouncementDatabase): Builder
-        @BindsInstance fun staffDatabase(database: StaffDatabase): Builder
-        @BindsInstance fun contributorDatabase(database: ContributorDatabase): Builder
-        @BindsInstance fun firestore(firestore: Firestore): Builder
-
-        fun build(): RepositoryComponent
+    @Component.Factory
+    interface Factory {
+        fun create(
+            @BindsInstance context: Context,
+            @BindsInstance droidKaigiApi: DroidKaigiApi,
+            @BindsInstance googleFormApi: GoogleFormApi,
+            @BindsInstance sessionDatabase: SessionDatabase,
+            @BindsInstance sponsorDatabase: SponsorDatabase,
+            @BindsInstance announcementDatabase: AnnouncementDatabase,
+            @BindsInstance staffDatabase: StaffDatabase,
+            @BindsInstance contributorDatabase: ContributorDatabase,
+            @BindsInstance firestore: Firestore
+        ): RepositoryComponent
     }
 
     companion object {
-        fun builder(): Builder = DaggerRepositoryComponent.builder()
+        fun factory(): Factory = DaggerRepositoryComponent.factory()
     }
 }

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -15,13 +15,13 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import io.github.droidkaigi.confsched2020.App
-import io.github.droidkaigi.confsched2020.di.AppComponent
-import io.github.droidkaigi.confsched2020.di.PageScope
-import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.contributor.R
 import io.github.droidkaigi.confsched2020.contributor.databinding.FragmentContributorsBinding
 import io.github.droidkaigi.confsched2020.contributor.ui.di.ContributorAssistedInjectModule
 import io.github.droidkaigi.confsched2020.contributor.ui.viewmodel.ContributorsViewModel
+import io.github.droidkaigi.confsched2020.di.AppComponent
+import io.github.droidkaigi.confsched2020.di.PageScope
+import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -55,10 +55,8 @@ class ContributorsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val appComponent = (requireContext().applicationContext as App).appComponent
-        val component = DaggerContributorComponent.builder()
-            .appComponent(appComponent)
-            .contributorModule(ContributorModule(this))
-            .build()
+        val component = DaggerContributorComponent.factory()
+            .create(appComponent, ContributorModule(this))
         component.inject(this)
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
@@ -93,11 +91,12 @@ class ContributorModule(private val fragment: ContributorsFragment) {
     dependencies = [AppComponent::class]
 )
 interface ContributorComponent {
-    @Component.Builder
-    interface Builder {
-        fun build(): ContributorComponent
-        fun appComponent(appComponent: AppComponent): Builder
-        fun contributorModule(contributorModule: ContributorModule): Builder
+    @Component.Factory
+    interface Factory {
+        fun create(
+            appComponent: AppComponent,
+            contributorModule: ContributorModule
+        ): ContributorComponent
     }
 
     fun inject(fragment: ContributorsFragment)

--- a/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
@@ -49,10 +49,8 @@ class PreferencesFragment : PreferenceFragmentCompat() {
         super.onViewCreated(view, savedInstanceState)
 
         val appComponent = (requireContext().applicationContext as App).appComponent
-        val component = DaggerPreferenceComponent.builder()
-            .appComponent(appComponent)
-            .preferenceModule(PreferenceModule(this))
-            .build()
+        val component = DaggerPreferenceComponent.factory()
+            .create(appComponent, PreferenceModule(this))
         component.inject(this)
     }
 
@@ -77,11 +75,12 @@ class PreferenceModule(private val fragment: PreferencesFragment) {
     dependencies = [AppComponent::class]
 )
 interface PreferenceComponent {
-    @Component.Builder
-    interface Builder {
-        fun build(): PreferenceComponent
-        fun appComponent(appComponent: AppComponent): Builder
-        fun preferenceModule(preferenceModule: PreferenceModule): Builder
+    @Component.Factory
+    interface Factory {
+        fun create(
+            appComponent: AppComponent,
+            preferenceModule: PreferenceModule
+        ): PreferenceComponent
     }
 
     fun inject(fragment: PreferencesFragment)

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -60,10 +60,8 @@ class StaffsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val appComponent = (requireContext().applicationContext as App).appComponent
-        val component = DaggerStaffComponent.builder()
-            .appComponent(appComponent)
-            .staffModule(StaffModule(this))
-            .build()
+        val component = DaggerStaffComponent.factory()
+            .create(appComponent, StaffModule(this))
         component.inject(this)
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
@@ -108,11 +106,9 @@ class StaffModule(private val fragment: StaffsFragment) {
     dependencies = [AppComponent::class]
 )
 interface StaffComponent {
-    @Component.Builder
-    interface Builder {
-        fun build(): StaffComponent
-        fun appComponent(appComponent: AppComponent): Builder
-        fun staffModule(staffModule: StaffModule): Builder
+    @Component.Factory
+    interface Factory {
+        fun create(appComponent: AppComponent, staffModule: StaffModule): StaffComponent
     }
 
     fun inject(fragment: StaffsFragment)


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Migrate from Dagger component builder to factory pattern introduced from Dagger 2.22
  - Just call a single method to create components
  - It is worth to avoid forgetting to call some builder methods

## Links
- https://github.com/google/dagger/releases/tag/dagger-2.22
- https://proandroiddev.com/dagger-and-the-shiny-new-component-factory-c2234fcae6b1

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
