### PR TITLE
remove Shopify's livedata-ktx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ This project uses some modern Android libraries and source codes.
 * [OkHttp](http://square.github.io/okhttp/) (Square)
   * Client
   * LoggingInterceptor
-* [livedata-ktx](https://github.com/Shopify/livedata-ktx) (Shopify)
 * [Coil](https://github.com/coil-kt/coil) (Coil Contributors)
 * [LeakCanary](https://github.com/square/leakcanary) (Square)
 * [Stetho](http://facebook.github.io/stetho/) (Facebook)

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -164,7 +164,6 @@ object Dep {
         val okio = "com.squareup.okio:okio:1.14.0"
     }
 
-    val shopifyLiveDataKtx = "com.shopify:livedata-ktx:3.0.0"
     val liveEvent = "com.github.hadilq.liveevent:liveevent:1.0.1"
 
     object LeakCanary {


### PR DESCRIPTION
## Issue
- close #143 

## Overview (Required)
- remove Shopify's livedata-ktx that is in Readme and Dep.ktx
