### PR TITLE
Fixed a fragment view leak by using DataBinding-ktx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ allprojects {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         maven { url "https://dl.bintray.com/kotlin/ktor" }
         maven { url "https://dl.bintray.com/kotlin/kotlinx" }
+        maven { url 'https://jitpack.io' }
     }
     plugins.whenPluginAdded {
         if (it.isAndroidApp() || it.isAndroidLibrary() || it.isDynamicFeature()) {

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -222,4 +222,9 @@ object Dep {
     object Insetter {
         val insetter = "dev.chrisbanes:insetter-ktx:0.2.0"
     }
+
+    object DataBindingKtx {
+        val version = "3.0.1"
+        val dataBindingKtx = "com.github.wada811:DataBinding-ktx:$version"
+    }
 }

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -6,9 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -40,7 +40,7 @@ class AboutFragment : DaggerFragment() {
         systemViewModelProvider.get()
     }
 
-    private lateinit var binding: FragmentAboutBinding
+    private val binding: FragmentAboutBinding by dataBinding(R.layout.fragment_about)
 
     private lateinit var progressTimeLatch: ProgressTimeLatch
 
@@ -49,12 +49,6 @@ class AboutFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_about,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/announcement/build.gradle
+++ b/feature/announcement/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -8,11 +8,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.RecyclerView
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.ViewHolder
@@ -50,7 +50,7 @@ class AnnouncementFragment : DaggerFragment() {
     @Inject
     lateinit var announcementItemFactory: AnnouncementItem.Factory
 
-    private lateinit var binding: FragmentAnnouncementBinding
+    private val binding: FragmentAnnouncementBinding by dataBinding(R.layout.fragment_announcement)
 
     private lateinit var progressTimeLatch: ProgressTimeLatch
 
@@ -58,12 +58,6 @@ class AnnouncementFragment : DaggerFragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_announcement,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/contributor/build.gradle
+++ b/feature/contributor/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions
     testImplementation Dep.MockK.jvm

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -5,10 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Component
@@ -28,7 +28,7 @@ import javax.inject.Provider
 
 class ContributorsFragment : Fragment() {
 
-    private lateinit var binding: FragmentContributorsBinding
+    private val binding: FragmentContributorsBinding by dataBinding(R.layout.fragment_contributors)
 
     @Inject lateinit var contributorsFactory: Provider<ContributorsViewModel>
     private val contributorsViewModel by assistedViewModels {
@@ -42,12 +42,6 @@ class ContributorsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_contributors,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/floormap/build.gradle
+++ b/feature/floormap/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     compileOnly Dep.Dagger.assistedInjectAnnotations
     kapt Dep.Dagger.assistedInjectProcessor
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -4,9 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import com.wada811.databinding.dataBinding
 import dagger.Module
 import dagger.Provides
 import dagger.android.support.DaggerFragment
@@ -17,18 +17,13 @@ import io.github.droidkaigi.confsched2020.floormap.databinding.FragmentFloormapB
 // TODO: Apply the floor map UI
 class FloorMapFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentFloormapBinding
+    private val binding: FragmentFloormapBinding by dataBinding(R.layout.fragment_floormap)
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_floormap,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session/build.gradle
+++ b/feature/session/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
@@ -6,11 +6,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
 import androidx.transition.TransitionManager
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -33,7 +33,7 @@ import javax.inject.Provider
 
 class BottomSheetDaySessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentBottomSheetSessionsBinding
+    private val binding: FragmentBottomSheetSessionsBinding by dataBinding(R.layout.fragment_bottom_sheet_sessions)
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -65,12 +65,6 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_bottom_sheet_sessions,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -5,10 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -27,7 +27,7 @@ import javax.inject.Provider
 
 class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentBottomSheetSessionsBinding
+    private val binding: FragmentBottomSheetSessionsBinding by dataBinding(R.layout.fragment_bottom_sheet_sessions)
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -50,12 +50,6 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_bottom_sheet_sessions,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.lifecycle.LifecycleOwner
@@ -18,6 +17,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
+import com.wada811.databinding.dataBinding
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -37,7 +37,7 @@ import javax.inject.Provider
 
 class MainSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentMainSessionsBinding
+    private val binding: FragmentMainSessionsBinding by dataBinding(R.layout.fragment_main_sessions)
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -60,12 +60,6 @@ class MainSessionsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_main_sessions,
-            container,
-            false
-        )
         setHasOptionsMenu(true)
         return binding.root
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -7,10 +7,10 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -32,7 +32,7 @@ import javax.inject.Provider
 
 class SearchSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSearchSessionsBinding
+    private val binding: FragmentSearchSessionsBinding by dataBinding(R.layout.fragment_search_sessions)
 
     @Inject lateinit var searchSessionsModelFactory: SearchSessionsViewModel.Factory
     private val searchSessionsViewModel by assistedViewModels {
@@ -68,12 +68,6 @@ class SearchSessionsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_search_sessions,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -18,6 +17,7 @@ import coil.Coil
 import coil.api.load
 import coil.transform.CircleCropTransformation
 import com.google.android.material.chip.Chip
+import com.wada811.databinding.dataBinding
 import dagger.Module
 import dagger.Provides
 import dagger.android.support.DaggerFragment
@@ -43,7 +43,7 @@ import javax.inject.Provider
 
 class SessionDetailFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSessionDetailBinding
+    private val binding: FragmentSessionDetailBinding by dataBinding(R.layout.fragment_session_detail)
 
     @Inject lateinit var systemViewModelFactory: Provider<SystemViewModel>
     private val systemViewModel by assistedActivityViewModels {
@@ -64,12 +64,6 @@ class SessionDetailFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_session_detail,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -6,13 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.chip.ChipGroup
+import com.wada811.databinding.dataBinding
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -36,7 +36,7 @@ import javax.inject.Provider
 
 class SessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSessionsBinding
+    private val binding: FragmentSessionsBinding by dataBinding(R.layout.fragment_sessions)
 
     private val sessionSheetBehavior: BottomSheetBehavior<*>
         get() {
@@ -76,12 +76,6 @@ class SessionsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_sessions,
-            container,
-            false
-        )
         setHasOptionsMenu(true)
         return binding.root
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
@@ -16,6 +15,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.api.load
 import coil.transform.CircleCropTransformation
+import com.wada811.databinding.dataBinding
 import dagger.Module
 import dagger.Provides
 import dagger.android.support.DaggerFragment
@@ -33,7 +33,7 @@ import javax.inject.Inject
 
 class SpeakerFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSpeakerBinding
+    private val binding: FragmentSpeakerBinding by dataBinding(R.layout.fragment_speaker)
 
     @Inject lateinit var speakerViewModelFactory: SpeakerViewModel.Factory
     private val speakerViewModel by assistedViewModels {
@@ -48,12 +48,6 @@ class SpeakerFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_speaker,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/session_survey/build.gradle
+++ b/feature/session_survey/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.fragment.navArgs
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -42,7 +42,7 @@ class SessionSurveyFragment : DaggerFragment() {
     }
 
     private val navArgs: SessionSurveyFragmentArgs by navArgs()
-    private lateinit var binding: FragmentSessionSurveyBinding
+    private val binding: FragmentSessionSurveyBinding by dataBinding(R.layout.fragment_session_survey)
 
     private lateinit var progressTimeLatch: ProgressTimeLatch
 
@@ -51,12 +51,6 @@ class SessionSurveyFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_session_survey,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/sponsor/build.gradle
+++ b/feature/sponsor/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -5,11 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.GridLayoutManager
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.Item
 import com.xwray.groupie.Section
@@ -36,7 +36,7 @@ import javax.inject.Provider
 
 class SponsorsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSponsorsBinding
+    private val binding: FragmentSponsorsBinding by dataBinding(R.layout.fragment_sponsors)
 
     @Inject lateinit var sponsorsModelFactory: Provider<SponsorsViewModel>
     private val sponsorsViewModel by assistedViewModels {
@@ -60,12 +60,6 @@ class SponsorsFragment : DaggerFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_sponsors,
-            container,
-            false
-        )
         return binding.root
     }
 

--- a/feature/staff/build.gradle
+++ b/feature/staff/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    implementation Dep.DataBindingKtx.dataBindingKtx
+
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions
     testImplementation Dep.MockK.jvm

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -5,11 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
+import com.wada811.databinding.dataBinding
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Component
@@ -31,7 +31,7 @@ import javax.inject.Provider
 
 class StaffsFragment : Fragment() {
 
-    private lateinit var binding: FragmentStaffsBinding
+    private val binding: FragmentStaffsBinding by dataBinding(R.layout.fragment_staffs)
 
     @Inject lateinit var staffsFactory: Provider<StaffsViewModel>
     private val staffsViewModel by assistedViewModels {
@@ -47,12 +47,6 @@ class StaffsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_staffs,
-            container,
-            false
-        )
         return binding.root
     }
 


### PR DESCRIPTION
## Issue
- close #153

## Overview (Required)

- References to view remain unintentionally when add a fragment to a backstack.
- You can destroy the reference by setting `binding = null` in `Fragment#onDestroyView` lifecycle, but introduced [wada811/DataBinding-ktx](https://github.com/wada811/DataBinding-ktx) which does it automatically.

## Links

- https://github.com/wada811/DataBinding-ktx
- https://twitter.com/Piwai/status/1201686009349455872