### PR TITLE
#119 Fix top start time text not to be moved by scrolling up

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
@@ -33,7 +33,7 @@ class SessionsItemDecoration(
         res.getDimensionPixelSize(R.dimen.session_time_space)
     }
     private val sessionTimeTextMarginTopInPx by lazy {
-        res.getDimensionPixelSize(R.dimen.session_time_text_margin_top)
+        res.getDimensionPixelSize(R.dimen.session_time_text_margin_top).toFloat()
     }
 
     override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
@@ -33,7 +33,7 @@ class SessionsItemDecoration(
         res.getDimensionPixelSize(R.dimen.session_time_space)
     }
     private val sessionTimeTextMarginTopInPx by lazy {
-        res.getDimensionPixelSize(R.dimen.session_time_text_margin_top).toFloat()
+        res.getDimensionPixelSize(R.dimen.session_time_text_margin_top)
     }
 
     override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
@@ -67,7 +67,7 @@ class SessionsItemDecoration(
         } else null
 
         var positionY =
-            view.top.coerceAtLeast(0) + sessionTimeTextMarginTopInPx + sessionTimeTextSizeInPx
+            view.top.coerceAtLeast(sessionTimeTextMarginTopInPx.toInt()) + sessionTimeTextMarginTopInPx + sessionTimeTextSizeInPx
         if (sessionItem.startSessionTime() != nextSessionItem?.startSessionTime()) {
             positionY = positionY.coerceAtMost(view.bottom.toFloat())
         }


### PR DESCRIPTION
## Issue
- #119

## Overview (Required)
- Add same margin as sessionTimeTextMarginTopInPx to position that after scrolling.

## Screenshot

|Before|After|
|-|-|
|![droid0](https://user-images.githubusercontent.com/12192769/72365208-21ed0100-373b-11ea-8e47-8d711bf14c3e.gif)|![droid1](https://user-images.githubusercontent.com/12192769/72365235-2b766900-373b-11ea-8d57-eba6713090dd.gif)|
