### PR TITLE
Session search/filter box and result section headers are now localizable

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -86,14 +86,14 @@ class SearchSessionsFragment : DaggerFragment() {
             groupAdapter.clear()
 
             if (uiModel.searchResult.speakers.isNotEmpty()) {
-                groupAdapter.add(sectionHeaderItemFactory.create("Speaker"))
+                groupAdapter.add(sectionHeaderItemFactory.create(resources.getString(R.string.speaker)))
                 groupAdapter.addAll(uiModel.searchResult.speakers.map {
                     speakerItemFactory.create(it)
                 })
             }
             
             if (uiModel.searchResult.sessions.isNotEmpty()) {
-                groupAdapter.add(sectionHeaderItemFactory.create("Session"))
+                groupAdapter.add(sectionHeaderItemFactory.create(resources.getString(R.string.session)))
                 groupAdapter.addAll(uiModel.searchResult.sessions.map {
                     sessionItemFactory.create(it, sessionsViewModel)
                 })
@@ -106,7 +106,7 @@ class SearchSessionsFragment : DaggerFragment() {
         inflater.inflate(R.menu.menu_search_sessions, menu)
         val searchView = menu.findItem(R.id.search_view).actionView as SearchView
         searchView.isIconified = false
-        searchView.queryHint = "検索する"
+        searchView.queryHint = resources.getString(R.string.query_hint)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(s: String): Boolean {
                 return false

--- a/feature/session/src/main/res/values-jp/strings.xml
+++ b/feature/session/src/main/res/values-jp/strings.xml
@@ -5,4 +5,7 @@
     <string name="intended_audience_title">対象者</string>
     <string name="applicable_session">該当セッション: %1$d</string>
     <string name="filter_reset">リセット</string>
+    <string name="speaker">スピーカー</string>
+    <string name="session">セッション</string>
+    <string name="query_hint">検索する</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="filter_audience_category" translatable="false">Level</string>
     <string name="filter_category" translatable="false">Category</string>
     <string name="filter_language_support" translatable="false">Language Support</string>
+    <string name="speaker">Speaker</string>
+    <string name="session">Session</string>
+    <string name="query_hint">Search</string>
 </resources>


### PR DESCRIPTION
The query box was Japanese, and the result section headers were English,
both in direct strings.