### PR TITLE
Fix wrong case of method's name

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -89,7 +89,7 @@ abstract class AboutFragmentModule {
         @PageScope
         @JvmStatic
         @Provides
-        fun providesLifeCycleLiveData(
+        fun providesLifecycleOwnerLiveData(
             aboutFragment: AboutFragment
         ): LiveData<LifecycleOwner> {
             return aboutFragment.viewLifecycleOwnerLiveData

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -120,7 +120,7 @@ class AnnouncementFragment : DaggerFragment() {
             @PageScope
             @JvmStatic
             @Provides
-            fun providesLifeCycleLiveData(
+            fun providesLifecycleOwnerLiveData(
                 announcementFragment: AnnouncementFragment
             ): LiveData<LifecycleOwner> {
                 return announcementFragment.viewLifecycleOwnerLiveData

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -41,7 +41,7 @@ class FloorMapFragment : DaggerFragment() {
             @PageScope
             @JvmStatic
             @Provides
-            fun providesLifeCycleLiveData(
+            fun providesLifecycleOwnerLiveData(
                 floorMapFragment: FloorMapFragment
             ): LiveData<LifecycleOwner> {
                 return floorMapFragment.viewLifecycleOwnerLiveData

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -131,7 +131,7 @@ abstract class SearchSessionsFragmentModule {
     @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides fun providesLifeCycleLiveData(
+        @JvmStatic @Provides fun providesLifecycleOwnerLiveData(
             searchSessionsFragment: SearchSessionsFragment
         ): LiveData<LifecycleOwner> {
             return searchSessionsFragment.viewLifecycleOwnerLiveData

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -189,7 +189,7 @@ abstract class SessionDetailFragmentModule {
     @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides fun providesLifeCycleLiveData(
+        @JvmStatic @Provides fun providesLifecycleOwnerLiveData(
             sessionDetailFragment: SessionDetailFragment
         ): LiveData<LifecycleOwner> {
             return sessionDetailFragment.viewLifecycleOwnerLiveData

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -106,7 +106,7 @@ abstract class SpeakerFragmentModule {
     @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides fun providesLifeCycleLiveData(
+        @JvmStatic @Provides fun providesLifecycleOwnerLiveData(
             speakerFragment: SpeakerFragment
         ): LiveData<LifecycleOwner> {
             return speakerFragment.viewLifecycleOwnerLiveData

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -77,7 +77,7 @@ abstract class SessionSurveyFragmentModule {
         @PageScope
         @JvmStatic
         @Provides
-        fun providesLifeCycleLiveData(
+        fun providesLifecycleOwnerLiveData(
             sessionSurveyFragment: SessionSurveyFragment
         ): LiveData<LifecycleOwner> {
             return sessionSurveyFragment.viewLifecycleOwnerLiveData

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -134,7 +134,7 @@ abstract class SponsorsFragmentModule {
     @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides fun providesLifeCycleLiveData(
+        @JvmStatic @Provides fun providesLifecycleOwnerLiveData(
             sponsorsFragment: SponsorsFragment
         ): LiveData<LifecycleOwner> {
             return sponsorsFragment.viewLifecycleOwnerLiveData


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Fix wrong case
    - LifeCycle -> Lifecycle
- Fix method's name (unify with other method's name)
    - providesLifecycleLiveData -> providesLifecycleOwnerLiveData

## Links
- N/A

## Screenshot
- N/A