### PR TITLE
[SessionDetail] disable chip click

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -110,9 +110,11 @@ class SessionDetailFragment : DaggerFragment() {
                 binding.tags.removeAllViews()
                 binding.tags.addView(Chip(context).apply {
                     text = categoryLabel
+                    isClickable = false
                 })
                 binding.tags.addView(Chip(context).apply {
                     text = langLabel
+                    isClickable = false
                 })
                 binding.tags.tag = newTag
             }


### PR DESCRIPTION
## Issue
- close #120 

## Overview (Required)
- Set disable `clickable` labels at session detail screen

## Links
- N/A

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/6898223/72484684-716d2300-3848-11ea-81a5-be56df0a38dc.gif)" | ![after](https://user-images.githubusercontent.com/6898223/72484689-76ca6d80-3848-11ea-86ed-194661387623.gif)
