### PR TITLE
Apply AutoCleardValue to Fragment member variables

### DIFF
--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/AutoClearedValue.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/AutoClearedValue.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.droidkaigi.confsched2020.util
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.observe
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * see: https://github.com/android/architecture-components-samples/blob/9826b59956eb93c9e627bdf16a19a1c8bc28ce14/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt
+ *
+ * A lazy property that gets cleaned up when the fragment's view is destroyed.
+ *
+ * Accessing this variable while the fragment's view is destroyed will throw NPE.
+ */
+class AutoClearedValue<T : Any>(val fragment: Fragment) : ReadWriteProperty<Fragment, T> {
+    private var _value: T? = null
+
+    init {
+        fragment.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                fragment.viewLifecycleOwnerLiveData.observe(fragment) { viewLifecycleOwner ->
+                    viewLifecycleOwner?.lifecycle?.addObserver(object : DefaultLifecycleObserver {
+                        override fun onDestroy(owner: LifecycleOwner) {
+                            _value = null
+                        }
+                    })
+                }
+            }
+        })
+    }
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        return _value ?: throw IllegalStateException(
+            "should never call auto-cleared-value get when it might not be available"
+        )
+    }
+
+    override fun setValue(thisRef: Fragment, property: KProperty<*>, value: T) {
+        _value = value
+    }
+}
+
+/**
+ * Creates an [AutoClearedValue] associated with this fragment.
+ */
+fun <T : Any> Fragment.autoCleared() = AutoClearedValue<T>(this)

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -9,6 +9,7 @@ import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import com.google.android.material.internal.ViewUtils.doOnApplyWindowInsets
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -23,6 +24,7 @@ import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -40,9 +42,9 @@ class AboutFragment : DaggerFragment() {
         systemViewModelProvider.get()
     }
 
-    private lateinit var binding: FragmentAboutBinding
+    private var binding: FragmentAboutBinding by autoCleared()
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -27,6 +27,7 @@ import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -47,9 +48,9 @@ class AnnouncementFragment : DaggerFragment() {
     @Inject
     lateinit var announcementItemFactory: AnnouncementItem.Factory
 
-    private lateinit var binding: FragmentAnnouncementBinding
+    private var binding: FragmentAnnouncementBinding by autoCleared()
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -23,19 +23,20 @@ import io.github.droidkaigi.confsched2020.di.AppComponent
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class ContributorsFragment : Fragment() {
 
-    private lateinit var binding: FragmentContributorsBinding
+    private var binding: FragmentContributorsBinding by autoCleared()
 
     @Inject lateinit var contributorsFactory: Provider<ContributorsViewModel>
     private val contributorsViewModel by assistedViewModels {
         contributorsFactory.get()
     }
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -13,11 +13,12 @@ import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.floormap.R
 import io.github.droidkaigi.confsched2020.floormap.databinding.FragmentFloormapBinding
+import io.github.droidkaigi.confsched2020.util.autoCleared
 
 // TODO: Apply the floor map UI
 class FloorMapFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentFloormapBinding
+    private var binding: FragmentFloormapBinding by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
@@ -28,12 +28,13 @@ import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewMod
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.session.ui.widget.SessionsItemDecoration
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class BottomSheetDaySessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentBottomSheetSessionsBinding
+    private var binding: FragmentBottomSheetSessionsBinding by autoCleared()
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -22,12 +22,13 @@ import io.github.droidkaigi.confsched2020.session.databinding.FragmentBottomShee
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewModel
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentBottomSheetSessionsBinding
+    private var binding: FragmentBottomSheetSessionsBinding by autoCleared()
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -31,12 +31,13 @@ import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class MainSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentMainSessionsBinding
+    private var binding: FragmentMainSessionsBinding by autoCleared()
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -52,7 +53,7 @@ class MainSessionsFragment : DaggerFragment() {
     @Inject
     lateinit var sessionItemFactory: SessionItem.Factory
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -31,12 +31,13 @@ import io.github.droidkaigi.confsched2020.session.ui.item.SpeakerItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SearchSessionsViewModel
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class SearchSessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSearchSessionsBinding
+    private var binding: FragmentSearchSessionsBinding by autoCleared()
 
     @Inject lateinit var searchSessionsModelFactory: SearchSessionsViewModel.Factory
     private val searchSessionsViewModel by assistedViewModels {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -40,12 +40,13 @@ import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionDetailViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class SessionDetailFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSessionDetailBinding
+    private var binding: FragmentSessionDetailBinding by autoCleared()
 
     @Inject lateinit var systemViewModelFactory: Provider<SystemViewModel>
     private val systemViewModel by assistedActivityViewModels {
@@ -59,7 +60,7 @@ class SessionDetailFragment : DaggerFragment() {
     private val navArgs: SessionDetailFragmentArgs by navArgs()
     @Inject lateinit var sessionItemFactory: SessionItem.Factory
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -31,12 +31,13 @@ import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewMod
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.ui.widget.FilterChip
 import io.github.droidkaigi.confsched2020.ui.widget.onCheckedChanged
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class SessionsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSessionsBinding
+    private var binding: FragmentSessionsBinding by autoCleared()
 
     private val sessionSheetBehavior: BottomSheetBehavior<*>
         get() {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -29,11 +29,12 @@ import io.github.droidkaigi.confsched2020.session.databinding.FragmentSpeakerBin
 import io.github.droidkaigi.confsched2020.session.ui.SpeakerFragmentDirections.actionSpeakerToSessionDetail
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SpeakerViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 
 class SpeakerFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSpeakerBinding
+    private var binding: FragmentSpeakerBinding by autoCleared()
 
     @Inject lateinit var speakerViewModelFactory: SpeakerViewModel.Factory
     private val speakerViewModel by assistedViewModels {
@@ -41,7 +42,7 @@ class SpeakerFragment : DaggerFragment() {
     }
 
     private val navArgs: SpeakerFragmentArgs by navArgs()
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -20,6 +20,7 @@ import io.github.droidkaigi.confsched2020.session_survey.databinding.FragmentSes
 import io.github.droidkaigi.confsched2020.session_survey.ui.viewmodel.SessionSurveyViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -38,9 +39,9 @@ class SessionSurveyFragment : DaggerFragment() {
     }
 
     private val navArgs: SessionSurveyFragmentArgs by navArgs()
-    private lateinit var binding: FragmentSessionSurveyBinding
+    private var binding: FragmentSessionSurveyBinding by autoCleared()
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -31,12 +31,13 @@ import io.github.droidkaigi.confsched2020.sponsor.ui.item.SponsorItem
 import io.github.droidkaigi.confsched2020.sponsor.ui.viewmodel.SponsorsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class SponsorsFragment : DaggerFragment() {
 
-    private lateinit var binding: FragmentSponsorsBinding
+    private var binding: FragmentSponsorsBinding by autoCleared()
 
     @Inject lateinit var sponsorsModelFactory: Provider<SponsorsViewModel>
     private val sponsorsViewModel by assistedViewModels {
@@ -53,7 +54,7 @@ class SponsorsFragment : DaggerFragment() {
 
     @Inject lateinit var categoryHeaderItemFactory: CategoryHeaderItem.Factory
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -26,12 +26,13 @@ import io.github.droidkaigi.confsched2020.staff.ui.di.StaffAssistedInjectModule
 import io.github.droidkaigi.confsched2020.staff.ui.item.StaffItem
 import io.github.droidkaigi.confsched2020.staff.ui.viewmodel.StaffsViewModel
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
+import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
 class StaffsFragment : Fragment() {
 
-    private lateinit var binding: FragmentStaffsBinding
+    private var binding: FragmentStaffsBinding by autoCleared()
 
     @Inject lateinit var staffsFactory: Provider<StaffsViewModel>
     private val staffsViewModel by assistedViewModels {
@@ -40,7 +41,7 @@ class StaffsFragment : Fragment() {
 
     @Inject lateinit var staffItemFactory: StaffItem.Factory
 
-    private lateinit var progressTimeLatch: ProgressTimeLatch
+    private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
     override fun onCreateView(
         inflater: LayoutInflater,


### PR DESCRIPTION
## Issue
- close #153

## Overview (Required)

- References to view, adapter, and more remain unintentionally when add a fragment to a backstack.
- Applied [AutoClearedValue](https://github.com/android/architecture-components-samples/blob/9826b59956eb93c9e627bdf16a19a1c8bc28ce14/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt) solved this issue.
  - AutoClearedValue is a delegated property that implements ReadWriteProperty. Set null in the onDestroy life cycle of viewLifecycleOwner.lifecycle.

## Links

- https://github.com/DroidKaigi/conference-app-2020/pull/230