### PR TITLE
Toggle expand icon of BottomSheet sub header label on MYPLAN tab

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -74,6 +74,12 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
 
         sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
+            binding.sessionRecycler.isVisible = when (uiModel.expandFilterState) {
+                ExpandFilterState.EXPANDED, ExpandFilterState.CHANGING ->
+                    true
+                else ->
+                    false
+            }
             binding.startFilter.visibility = when (uiModel.expandFilterState) {
                 ExpandFilterState.EXPANDED, ExpandFilterState.CHANGING ->
                     View.VISIBLE

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -9,6 +9,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
+import androidx.transition.TransitionManager
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -16,6 +17,7 @@ import dagger.Provides
 import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
+import io.github.droidkaigi.confsched2020.model.ExpandFilterState
 import io.github.droidkaigi.confsched2020.model.SessionPage
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentBottomSheetSessionsBinding
@@ -65,6 +67,25 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
         binding.sessionRecycler.adapter = groupAdapter
         binding.startFilter.setOnClickListener {
             sessionTabViewModel.toggleExpand()
+        }
+        binding.expandLess.setOnClickListener {
+            sessionTabViewModel.toggleExpand()
+        }
+
+        sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
+            TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
+            binding.startFilter.visibility = when (uiModel.expandFilterState) {
+                ExpandFilterState.EXPANDED, ExpandFilterState.CHANGING ->
+                    View.VISIBLE
+                else ->
+                    View.INVISIBLE
+            }
+            binding.expandLess.isVisible = when (uiModel.expandFilterState) {
+                ExpandFilterState.COLLAPSED ->
+                    true
+                else ->
+                    false
+            }
         }
 
         sessionsViewModel.uiModel.observe(viewLifecycleOwner) { uiModel: SessionsViewModel.UiModel ->


### PR DESCRIPTION
## Issue
- close #310 

## Overview (Required)
- subscribe `uiModel.expandFilterState` and toggle Button / ImageView
- subscribe `uiModel.expandFilterState` and hide session list when collapsed
- I Implemented based on #263 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/18282993/72541669-46c1af80-38c6-11ea-964c-191e2b177e84.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/18282993/72546861-dbc8a680-38ce-11ea-8efb-d40c609caf3f.gif" width="300" />
