### PR TITLE
Add tap feedback to speaker session name

### DIFF
--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -155,6 +155,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:background="?attr/selectableItemBackground"
                     android:text="@{speechSession.title.getByLang(lang)}"
                     android:textAppearance="@style/TextAppearance.DroidKaigi.Subtitle2"
                     android:lineSpacingExtra="8sp"


### PR DESCRIPTION
## Issue
- close #316 

## Overview (Required)
- Add tap feedback to speaker session name of fragment_speaker.xml

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/17285905/72599762-a9ae5780-3955-11ea-8cf1-3cb4184da8fa.png" width="300" /> | <img src="https://user-images.githubusercontent.com/17285905/72599294-bc745c80-3954-11ea-8ad0-160211c0ad5a.png" width="300" />
