### PR TITLE
Hide keyboard when moved to other Fragment

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -1,11 +1,13 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
@@ -79,6 +81,15 @@ class SearchSessionsFragment : DaggerFragment() {
             false
         )
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        view?.let {
+            val imm =
+                context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as? InputMethodManager
+            imm?.hideSoftInputFromWindow(it.windowToken, 0);
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
## issue

close https://github.com/DroidKaigi/conference-app-2020/issues/133

## Overview (Required)

Hide keyboard when moved to other Fragment.

<img src=https://user-images.githubusercontent.com/8403570/72608522-35c87b00-3966-11ea-90b4-53d8d246e7b8.gif width=300>

I used `onDestroyView()` of Fragment because implementation is short and simple.
It seems to work but I'm not sure (because it's first time to use this way honestly). Please check whether appropriate or not 🙏 