### PR TITLE
Add link to AutoClearedValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ This project uses some modern Android libraries and source codes.
 * [Google I/O 2018](https://github.com/google/iosched) (Google)
 * [TimetableLayout](https://github.com/MoyuruAizawa/TimetableLayout) (MoyuruAizawa)
 * [Android Architecture Components samples](https://github.com/android/architecture-components-samples) (Google)
-  * [AutoClearedValue](https://github.com/android/architecture-components-samples/blob/master/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt)
+  * [AutoClearedValue](https://github.com/android/architecture-components-samples/blob/9826b59956eb93c9e627bdf16a19a1c8bc28ce14/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt)
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ This project uses some modern Android libraries and source codes.
 * [Injected ViewModel Provider](https://github.com/evant/injectedvmprovider) (evant)
 * [Google I/O 2018](https://github.com/google/iosched) (Google)
 * [TimetableLayout](https://github.com/MoyuruAizawa/TimetableLayout) (MoyuruAizawa)
+* [Android Architecture Components samples](https://github.com/android/architecture-components-samples) (Google)
+  * [AutoClearedValue](https://github.com/android/architecture-components-samples/blob/master/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt)
 
 ### iOS
 


### PR DESCRIPTION
## Issue
- close #330

## Overview (Required)
- Add link to AutoClearedValue to README
  - AutoClearedValue from Android Architecture Components samples

## Links
- [architecture\-components\-samples/AutoClearedValue\.kt at master · android/architecture\-components\-samples](https://github.com/android/architecture-components-samples/blob/master/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt)
