### PR TITLE
Open sponsor URLs through navigation

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/CustomNavHostFragment.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/CustomNavHostFragment.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched2020.ui
+
+import androidx.navigation.NavController
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.plusAssign
+
+class CustomNavHostFragment : NavHostFragment() {
+
+    override fun onCreateNavController(navController: NavController) {
+        super.onCreateNavController(navController)
+        context?.let {
+            navController.navigatorProvider += ChromeCustomTabsNavigator(it)
+        }
+    }
+}

--- a/android-base/src/main/res/layout/activity_main.xml
+++ b/android-base/src/main/res/layout/activity_main.xml
@@ -50,7 +50,7 @@
 
             <fragment
                 android:id="@+id/root_nav_host_fragment"
-                android:name="androidx.navigation.fragment.NavHostFragment"
+                android:name="io.github.droidkaigi.confsched2020.ui.CustomNavHostFragment"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 app:defaultNavHost="true"

--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(":model")
     implementation Dep.AndroidX.constraint
     implementation Dep.AndroidX.design
+    implementation Dep.AndroidX.browser
     implementation Dep.Kotlin.stdlibJvm
 
     api Dep.Insetter.insetter

--- a/corecomponent/androidcomponent/proguard-rules-navigation.pro
+++ b/corecomponent/androidcomponent/proguard-rules-navigation.pro
@@ -16,3 +16,4 @@
 -keepnames class io.github.droidkaigi.confsched2020.session_survey.ui.SessionSurveyFragment
 -keepnames class io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragment
 -keepnames class io.github.droidkaigi.confsched2020.staff.ui.StaffsFragment
+-keepnames class io.github.droidkaigi.confsched2020.ui.ChromeCustomTabsNavigator

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/ui/ChromeCustomTabsNavigator.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/ui/ChromeCustomTabsNavigator.kt
@@ -1,0 +1,64 @@
+package io.github.droidkaigi.confsched2020.ui
+
+import android.app.Activity
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.util.AttributeSet
+import android.util.Patterns
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.content.withStyledAttributes
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import io.github.droidkaigi.confsched2020.ext.getThemeColor
+import io.github.droidkaigi.confsched2020.widget.component.R
+
+@Navigator.Name("chrome")
+class ChromeCustomTabsNavigator(private val context: Context) : Navigator<ChromeCustomTabsNavigator.Destination>() {
+
+    override fun createDestination() = Destination(this)
+
+    override fun navigate(
+        destination: Destination,
+        args: Bundle?,
+        navOptions: NavOptions?,
+        navigatorExtras: Extras?
+    ): NavDestination? {
+        val url = args?.getString("url")
+            ?: throw IllegalStateException("Destination ${destination.id} does not have an url.")
+
+        if (destination.webUrl && url.isInvalidWebUrl()) {
+            throw IllegalArgumentException("Url($url) is a invalid web URL.")
+        }
+
+        val builder = CustomTabsIntent.Builder()
+            .setShowTitle(true)
+            .enableUrlBarHiding()
+            .setToolbarColor(context.getThemeColor(R.attr.colorAccent))
+
+        val intent = builder.build()
+        intent.launchUrl(context, Uri.parse(url))
+        return null // Do not add to the back stack, managed by Chrome Custom Tabs
+    }
+
+    private fun String.isInvalidWebUrl(): Boolean {
+        return Patterns.WEB_URL.matcher(this).matches().not()
+    }
+
+    override fun popBackStack() = true // Managed by Chrome Custom Tabs
+
+    @NavDestination.ClassType(Activity::class)
+    class Destination(navigator: Navigator<out NavDestination>) : NavDestination(navigator) {
+
+        var webUrl: Boolean = true
+
+        override fun onInflate(context: Context, attrs: AttributeSet) {
+            super.onInflate(context, attrs)
+
+            context.withStyledAttributes(attrs, R.styleable.ChromeCustomTabsNavigator, 0, 0) {
+                webUrl = getBoolean(R.styleable.ChromeCustomTabsNavigator_webUrl, true)
+            }
+        }
+    }
+}

--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -131,7 +131,20 @@
         android:id="@+id/sponsors"
         android:name="io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragment"
         android:label="@string/sponsor_label"
-        />
+        >
+
+        <action
+            android:id="@+id/action_sponsors_to_chrome"
+            app:destination="@id/chrome"
+            >
+
+            <argument
+                android:name="url"
+                app:argType="string"
+                app:nullable="false"
+                />
+        </action>
+    </fragment>
     <fragment
         android:id="@+id/contributor"
         android:name="io.github.droidkaigi.confsched2020.contributor.ui.ContributorsFragment"
@@ -169,5 +182,10 @@
         android:id="@+id/setting"
         android:name="io.github.droidkaigi.confsched2020.preference.ui.PreferencesFragment"
         android:label="@string/setting_label"
+        />
+    <chrome
+        android:id="@+id/chrome"
+        android:name="io.github.droidkaigi.confsched2020.ui.ChromeCustomTabsNavigator"
+        android:label="chrome"
         />
 </navigation>

--- a/corecomponent/androidcomponent/src/main/res/values/attrs.xml
+++ b/corecomponent/androidcomponent/src/main/res/values/attrs.xml
@@ -30,6 +30,10 @@
         <attr name="android:textSize" />
     </declare-styleable>
 
+    <declare-styleable name="ChromeCustomTabsNavigator">
+        <attr name="webUrl" format="boolean" />
+    </declare-styleable>
+
     <!-- workaround for https://issuetracker.google.com/issues/136103084#comment23 -->
     <attr name="flow_horizontalSeparator"/>
     <attr name="flow_verticalSeparator"/>

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -121,10 +121,10 @@ class SponsorsFragment : DaggerFragment() {
         return when (category) {
             SponsorCategory.Category.PLATINUM,
             SponsorCategory.Category.GOLD -> {
-                largeSponsorItemFactory.create(this, spanSize, systemViewModel)
+                largeSponsorItemFactory.create(this, spanSize)
             }
             else -> {
-                sponsorItemFactory.create(this, spanSize, systemViewModel)
+                sponsorItemFactory.create(this, spanSize)
             }
         }
     }

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/LargeSponsorItem.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/LargeSponsorItem.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2020.sponsor.ui.item
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import androidx.navigation.findNavController
 import coil.api.load
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
@@ -10,12 +11,11 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Sponsor
 import io.github.droidkaigi.confsched2020.sponsor.R
 import io.github.droidkaigi.confsched2020.sponsor.databinding.ItemSponsorLargeBinding
-import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.actionSponsorsToChrome
 
 class LargeSponsorItem @AssistedInject constructor(
     @Assisted private val sponsor: Sponsor,
     @Assisted private val spanSize: Int,
-    @Assisted private val systemViewModel: SystemViewModel,
     private val lifecycleOwnerLiveData: LiveData<LifecycleOwner>
 ) : BindableItem<ItemSponsorLargeBinding>(sponsor.id.toLong()),
     EqualableContentsProvider {
@@ -23,7 +23,7 @@ class LargeSponsorItem @AssistedInject constructor(
 
     override fun bind(viewBinding: ItemSponsorLargeBinding, position: Int) {
         viewBinding.card.setOnClickListener {
-            systemViewModel.openUrl(sponsor.company.url)
+            it.findNavController().navigate(actionSponsorsToChrome(sponsor.company.url))
         }
 
         viewBinding.image.load(sponsor.company.logoUrl) {
@@ -52,8 +52,7 @@ class LargeSponsorItem @AssistedInject constructor(
     interface Factory {
         fun create(
             sponsor: Sponsor,
-            spanSize: Int,
-            systemViewModel: SystemViewModel
+            spanSize: Int
         ): LargeSponsorItem
     }
 }

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/SponsorItem.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/SponsorItem.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2020.sponsor.ui.item
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import androidx.navigation.findNavController
 import coil.api.load
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
@@ -10,12 +11,11 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Sponsor
 import io.github.droidkaigi.confsched2020.sponsor.R
 import io.github.droidkaigi.confsched2020.sponsor.databinding.ItemSponsorBinding
-import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.actionSponsorsToChrome
 
 class SponsorItem @AssistedInject constructor(
     @Assisted private val sponsor: Sponsor,
     @Assisted private val spanSize: Int,
-    @Assisted private val systemViewModel: SystemViewModel,
     private val lifecycleOwnerLiveData: LiveData<LifecycleOwner>
 ) : BindableItem<ItemSponsorBinding>(sponsor.id.toLong()),
     EqualableContentsProvider {
@@ -23,7 +23,7 @@ class SponsorItem @AssistedInject constructor(
 
     override fun bind(viewBinding: ItemSponsorBinding, position: Int) {
         viewBinding.card.setOnClickListener {
-            systemViewModel.openUrl(sponsor.company.url)
+            it.findNavController().navigate(actionSponsorsToChrome(sponsor.company.url))
         }
 
         viewBinding.image.load(sponsor.company.logoUrl) {
@@ -52,8 +52,7 @@ class SponsorItem @AssistedInject constructor(
     interface Factory {
         fun create(
             sponsor: Sponsor,
-            spanSize: Int,
-            systemViewModel: SystemViewModel
+            spanSize: Int
         ): SponsorItem
     }
 }

--- a/feature/system/build.gradle
+++ b/feature/system/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     implementation Dep.AndroidX.recyclerView
     implementation Dep.AndroidX.emoji
     implementation Dep.AndroidX.design
-    implementation Dep.AndroidX.browser
 
     implementation Dep.Dagger.core
     implementation Dep.Dagger.androidSupport

--- a/feature/system/src/main/java/io/github/droidkaigi/confsched2020/system/ui/viewmodel/SystemViewModel.kt
+++ b/feature/system/src/main/java/io/github/droidkaigi/confsched2020/system/ui/viewmodel/SystemViewModel.kt
@@ -1,38 +1,17 @@
 package io.github.droidkaigi.confsched2020.system.ui.viewmodel
 
-import android.content.Intent
-import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.ext.toNonNullSingleEvent
 import io.github.droidkaigi.confsched2020.model.AppError
-import io.github.droidkaigi.confsched2020.system.R
 import javax.inject.Inject
 
 class SystemViewModel @Inject constructor(
-    val activity: FragmentActivity
 ) : ViewModel() {
     private val mutableErrorLiveData = MutableLiveData<AppError?>()
     val errorLiveData: LiveData<AppError> get() = mutableErrorLiveData.toNonNullSingleEvent()
     fun onError(error: AppError) {
         mutableErrorLiveData.value = error
-    }
-
-    fun openUrl(url: String) {
-        val customTabsIntent = CustomTabsIntent.Builder()
-            .setShowTitle(true)
-            .enableUrlBarHiding()
-            .setToolbarColor(activity.getThemeColor(R.attr.colorAccent))
-            .build()
-
-        // block to multiple launch a Activity
-        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-
-        // launch a Custom Tabs Activity
-        customTabsIntent.launchUrl(activity, Uri.parse(url))
     }
 }


### PR DESCRIPTION
## Issue
- close #324

## Overview (Required)
- Open sponsor URLs through navigation

## Links
- https://proandroiddev.com/add-chrome-custom-tabs-to-the-android-navigation-component-75092ce20c6a

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/72613244-61e9f900-3972-11ea-9c53-11cdfd5ec862.gif" width="300" />