### PR TITLE
A part of TextView padding between lines

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -214,6 +214,7 @@
                     android:text="@{speechSession.intendedAudience}"
                     android:textAppearance="@style/TextAppearance.DroidKaigi.Body1"
                     android:textColor="?android:attr/textColorPrimary"
+                    android:lineSpacingExtra="8sp"
                     app:isVisible="@{session.hasIntendedAudience}"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"


### PR DESCRIPTION
Sorry, I Forgot to add `android:lineSpacingExtra ` to a part of TextView :bow:

## Issue
- close #306 

## Overview (Required)
- I think we should increase the spacing between lines in whole textview.

## Links

- https://www.figma.com/file/4r9becvhDy3GfXaXex8E8d/App?node-id=21%3A395
- https://developer.android.com/reference/android/widget/TextView.html#attr_android:lineSpacingExtra


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/893643/72614676-41bc3900-3976-11ea-897b-dc979406e984.png" width="300" /> | <img src="https://user-images.githubusercontent.com/893643/72614678-41bc3900-3976-11ea-9d28-44d7aee7504b.png" width="300" />
