### PR TITLE
Replace Fabric Crashlytics library to Firebase

### DIFF
--- a/android-base/build.gradle
+++ b/android-base/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     compileSdkVersion Versions.androidCompileSdkVersion
@@ -95,6 +95,7 @@ dependencies {
     implementation Dep.AndroidX.activityKtx
     implementation Dep.Firebase.firestoreKtx
     implementation Dep.Firebase.crashlytics
+    implementation Dep.Firebase.analytics
 
     implementation Dep.Dagger.core
     implementation Dep.Dagger.androidSupport

--- a/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DebugApp.kt
+++ b/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DebugApp.kt
@@ -1,11 +1,9 @@
 package io.github.droidkaigi.confsched2020
 
 import androidx.core.content.ContextCompat
-import com.crashlytics.android.Crashlytics
 import com.facebook.stetho.Stetho
 import com.facebook.stetho.dumpapp.DumperPlugin
 import com.facebook.stetho.inspector.protocol.ChromeDevtoolsDomain
-import io.fabric.sdk.android.Fabric
 import java.io.File
 
 class DebugApp : App() {
@@ -29,7 +27,5 @@ class DebugApp : App() {
                         .finish()
                 }
             })
-
-        Fabric.with(this, Crashlytics())
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url 'https://jitpack.io' }
-        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath Dep.GradlePlugin.android

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -6,12 +6,12 @@ object Dep {
         val android = "com.android.tools.build:gradle:3.6.0-rc01"
         val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         val kotlinSerialization = "org.jetbrains.kotlin:kotlin-serialization:${Kotlin.version}"
-        val playServices = "com.google.gms:google-services:4.3.0"
+        val playServices = "com.google.gms:google-services:4.3.3"
         val safeArgs =
             "androidx.navigation:navigation-safe-args-gradle-plugin:${AndroidX.Navigation.version}"
         val jetifier = "com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta05"
         val licensesPlugin = "com.google.android.gms:oss-licenses-plugin:0.9.5"
-        val crashlytics = "io.fabric.tools:gradle:1.28.0"
+        val crashlytics = "com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta01"
         val iconRibbonPlugin = "com.akaita.android:easylauncher:1.3.1"
         val gradleVersionsPlugin = "com.github.ben-manes:gradle-versions-plugin:0.22.0"
     }
@@ -117,7 +117,8 @@ object Dep {
         val core = "com.google.firebase:firebase-core:16.0.4"
         val firestoreKtx = "com.google.firebase:firebase-firestore-ktx:20.2.0"
         val auth = "com.google.firebase:firebase-auth:18.1.0"
-        val crashlytics = "com.crashlytics.sdk.android:crashlytics:2.9.8"
+        val crashlytics = "com.google.firebase:firebase-crashlytics:17.0.0-beta01"
+        val analytics = "com.google.firebase:firebase-analytics:17.2.2"
         val messaging = "com.google.firebase:firebase-messaging:17.3.3"
     }
 


### PR DESCRIPTION
## Issue
- close #332 

## Overview (Required)
- Replace to Firebase Crashlytics library. Thanks @takahirom 🙇

## Links
- https://firebase.google.com/docs/crashlytics/get-started-new-sdk?platform=android

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
