### PR TITLE
fix SearchSessionFragment : remember query text

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -25,6 +25,7 @@ import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
+import io.github.droidkaigi.confsched2020.ext.requireValue
 import io.github.droidkaigi.confsched2020.model.defaultLang
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentSearchSessionsBinding
@@ -157,7 +158,10 @@ class SearchSessionsFragment : DaggerFragment() {
             ContextCompat.getColor(requireContext(), R.color.search_close_icon)
         )
         searchView.isIconified = false
-        searchView.setQuery(searchSessionsViewModel.uiModel.value!!.searchResult.query, false)
+        val searchResult = searchSessionsViewModel.uiModel.requireValue().searchResult
+        if (!searchResult.isEmpty()) {
+            searchView.setQuery(searchResult.query, false)
+        }
         searchView.queryHint = resources.getString(R.string.query_hint)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(s: String): Boolean {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -157,6 +157,7 @@ class SearchSessionsFragment : DaggerFragment() {
             ContextCompat.getColor(requireContext(), R.color.search_close_icon)
         )
         searchView.isIconified = false
+        searchView.setQuery(searchSessionsViewModel.uiModel.value!!.searchResult.query, false)
         searchView.queryHint = resources.getString(R.string.query_hint)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(s: String): Boolean {

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SearchResult.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SearchResult.kt
@@ -5,6 +5,8 @@ class SearchResult(
     val speakers: List<Speaker>,
     val query: String?
 ) {
+    fun isEmpty() = this == EMPTY
+
     companion object {
         val EMPTY = SearchResult(listOf(), listOf(), null)
     }


### PR DESCRIPTION
fix SearchSessionFragment : remember query text, when come back after query searching

## Issue
- close #348 

## Overview (Required)
- Set(≒initialize) query text in `SearchSessionsFragment::onCreateOptionsMenu`.
(`SearchSessionsFragment::onCreateOptionsMenu`でクエリテキストの設定をしました。)
- Second arg of `searchView.setQuery()` is `false`. Because I think submit is unnecessary, In this case `searchResult` is remembered in `SearchSessionsViewModel`.
(`searchView.setQuery()`の第２引数は`false`にしています。この時検索結果はViewModelに覚えられていて、submitが不要と考えているためです。)

## Links
- none.

## Screenshot
- none.

Please let me know if there are strange points in my code & PR.🙏🙏🙏
(変なところがあったら教えてください！🙏🙏🙏)