### PR TITLE
Remove @JvmStatic annotations

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/ApiComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/ApiComponentModule.kt
@@ -10,7 +10,6 @@ import javax.inject.Singleton
 
 @Module
 object ApiComponentModule {
-    @JvmStatic
     @Provides
     @Singleton
     fun provideDroidKaigiApi(application: Application): DroidKaigiApi {
@@ -19,7 +18,6 @@ object ApiComponentModule {
             .DroidKaigiApi()
     }
 
-    @JvmStatic
     @Provides
     @Singleton
     fun provideGoogleFormApi(application: Application): GoogleFormApi {

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DbComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DbComponentModule.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Module
 object DbComponentModule {
-    @JvmStatic @Provides @Singleton fun provideItemStore(
+    @Provides @Singleton fun provideItemStore(
         application: Application
     ): SessionDatabase {
         return DbComponent.factory()
@@ -22,7 +22,7 @@ object DbComponentModule {
             .sessionDatabase()
     }
 
-    @JvmStatic @Provides @Singleton fun provideSponsorStore(
+    @Provides @Singleton fun provideSponsorStore(
         application: Application
     ): SponsorDatabase {
         return DbComponent.factory()
@@ -30,7 +30,7 @@ object DbComponentModule {
             .sponsorDatabase()
     }
 
-    @JvmStatic @Provides @Singleton fun provideAnnouncementStore(
+    @Provides @Singleton fun provideAnnouncementStore(
         application: Application
     ): AnnouncementDatabase {
         return DbComponent.factory()
@@ -38,7 +38,7 @@ object DbComponentModule {
             .announcementDatabase()
     }
 
-    @JvmStatic @Provides @Singleton fun provideStaffStore(
+    @Provides @Singleton fun provideStaffStore(
         application: Application
     ): StaffDatabase {
         return DbComponent.factory()
@@ -46,7 +46,7 @@ object DbComponentModule {
             .staffDatabase()
     }
 
-    @JvmStatic @Provides @Singleton fun provideContributorStore(
+    @Provides @Singleton fun provideContributorStore(
         application: Application
     ): ContributorDatabase {
         return DbComponent.factory()

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DeviceComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/DeviceComponentModule.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 
 @Module
 object DeviceComponentModule {
-    @JvmStatic @Provides @Singleton
+    @Provides @Singleton
     fun provideWifiManager(application: Application): WifiManager {
         return DeviceComponent.factory()
             .create(application)

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/FirestoreComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/FirestoreComponentModule.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 
 @Module
 object FirestoreComponentModule {
-    @JvmStatic @Provides @Singleton fun provideRepository(): Firestore {
+    @Provides @Singleton fun provideRepository(): Firestore {
         return FirestoreComponent.factory()
             .create(Dispatchers.IO)
             .firestore()

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/RepositoryComponentModule.kt
@@ -21,37 +21,37 @@ import javax.inject.Singleton
 
 @Module
 object RepositoryComponentModule {
-    @JvmStatic @Provides @Singleton fun provideRepository(
+    @Provides @Singleton fun provideRepository(
         repositoryComponent: RepositoryComponent
     ): SessionRepository {
         return repositoryComponent.sessionRepository()
     }
 
-    @JvmStatic @Provides @Singleton fun provideSponsorRepository(
+    @Provides @Singleton fun provideSponsorRepository(
         repositoryComponent: RepositoryComponent
     ): SponsorRepository {
         return repositoryComponent.sponsorRepository()
     }
 
-    @JvmStatic @Provides @Singleton fun provideAnnouncementRepository(
+    @Provides @Singleton fun provideAnnouncementRepository(
         repositoryComponent: RepositoryComponent
     ): AnnouncementRepository {
         return repositoryComponent.announcementRepository()
     }
 
-    @JvmStatic @Provides @Singleton fun provideStaffRepository(
+    @Provides @Singleton fun provideStaffRepository(
         repositoryComponent: RepositoryComponent
     ): StaffRepository {
         return repositoryComponent.staffRepository()
     }
 
-    @JvmStatic @Provides @Singleton fun provideContributorRepository(
+    @Provides @Singleton fun provideContributorRepository(
         repositoryComponent: RepositoryComponent
     ): ContributorRepository {
         return repositoryComponent.contributorRepository()
     }
 
-    @JvmStatic @Provides @Singleton fun provideRepositoryComponent(
+    @Provides @Singleton fun provideRepositoryComponent(
         context: Context,
         droidKaigiApi: DroidKaigiApi,
         googleFormApi: GoogleFormApi,

--- a/data/api/src/main/java/io/github/droidkaigi/confsched2020/data/api/internal/ApiModule.kt
+++ b/data/api/src/main/java/io/github/droidkaigi/confsched2020/data/api/internal/ApiModule.kt
@@ -25,7 +25,6 @@ internal abstract class ApiModule {
 
     @Module
     internal object Providers {
-        @JvmStatic
         @Provides
         fun httpClient(): HttpClient {
             return HttpClient(OkHttp) {
@@ -48,7 +47,6 @@ internal abstract class ApiModule {
             }
         }
 
-        @JvmStatic
         @Provides
         @Named("apiEndpoint")
         fun apiEndpoint(): String {

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/DbModule.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/DbModule.kt
@@ -30,7 +30,7 @@ internal abstract class DbModule {
 
     @Module
     internal object Providers {
-        @Singleton @JvmStatic @Provides fun cacheDatabase(
+        @Singleton @Provides fun cacheDatabase(
             context: Context,
             filename: String?
         ): CacheDatabase {
@@ -43,7 +43,7 @@ internal abstract class DbModule {
                 .build()
         }
 
-        @Singleton @JvmStatic @Provides fun sessionFeedbackDatabase(
+        @Singleton @Provides fun sessionFeedbackDatabase(
             context: Context,
             filename: String?
         ): SessionFeedbackDatabase {
@@ -56,37 +56,37 @@ internal abstract class DbModule {
                 .build()
         }
 
-        @JvmStatic @Provides fun sessionDao(database: CacheDatabase): SessionDao {
+        @Provides fun sessionDao(database: CacheDatabase): SessionDao {
             return database.sessionDao()
         }
 
-        @JvmStatic @Provides fun speakerDao(database: CacheDatabase): SpeakerDao {
+        @Provides fun speakerDao(database: CacheDatabase): SpeakerDao {
             return database.speakerDao()
         }
 
-        @JvmStatic @Provides fun sessionSpeakerJoinDao(
+        @Provides fun sessionSpeakerJoinDao(
             database: CacheDatabase
         ): SessionSpeakerJoinDao {
             return database.sessionSpeakerJoinDao()
         }
 
-        @JvmStatic @Provides fun sponsorDao(databaseSponsor: CacheDatabase): SponsorDao {
+        @Provides fun sponsorDao(databaseSponsor: CacheDatabase): SponsorDao {
             return databaseSponsor.sponsorDao()
         }
 
-        @JvmStatic @Provides fun announcementDao(database: CacheDatabase): AnnouncementDao {
+        @Provides fun announcementDao(database: CacheDatabase): AnnouncementDao {
             return database.announcementDao()
         }
 
-        @JvmStatic @Provides fun staffDao(database: CacheDatabase): StaffDao {
+        @Provides fun staffDao(database: CacheDatabase): StaffDao {
             return database.staffDao()
         }
 
-        @JvmStatic @Provides fun contributorDao(database: CacheDatabase): ContributorDao {
+        @Provides fun contributorDao(database: CacheDatabase): ContributorDao {
             return database.contributorDao()
         }
 
-        @JvmStatic @Provides fun sessionFeedbackDao(database: SessionFeedbackDatabase): SessionFeedbackDao {
+        @Provides fun sessionFeedbackDao(database: SessionFeedbackDatabase): SessionFeedbackDao {
             return database.sessionFeedbackDao()
         }
     }


### PR DESCRIPTION
## Issue
- Close #195 

## Overview (Required)
- As of Dagger 2.25.2, `@Module object` classes no longer need `@JvmStatic` on the provides methods, so removed them.

- But `@Module companion object` classes still need it (https://github.com/google/dagger/issues/1646).

## Links
- https://github.com/google/dagger/releases/tag/dagger-2.25.2

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
