### PR TITLE
Updated to use navigation component by Kotlin

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -65,11 +65,8 @@ object Dep {
         }
 
         object Navigation {
-            val version = "2.2.0-beta01"
-            val runtime = "androidx.navigation:navigation-runtime:$version"
+            val version = "2.2.0-rc04"
             val runtimeKtx = "androidx.navigation:navigation-runtime-ktx:$version"
-            val fragment = "androidx.navigation:navigation-fragment:$version"
-            val ui = "androidx.navigation:navigation-ui:$version"
             val fragmentKtx = "androidx.navigation:navigation-fragment-ktx:$version"
             val uiKtx = "androidx.navigation:navigation-ui-ktx:$version"
         }

--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -2,7 +2,7 @@ import dependencies.Dep
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'kotlin-kapt'
 
 apply from: rootProject.file('gradle/android.gradle')
@@ -25,7 +25,6 @@ dependencies {
     implementation Dep.Kotlin.stdlibJvm
     api Dep.Kotlin.coroutines
 
-    api Dep.AndroidX.Navigation.runtime
     api Dep.AndroidX.Navigation.runtimeKtx
     api Dep.AndroidX.Navigation.fragmentKtx
     api Dep.AndroidX.Navigation.uiKtx
@@ -37,7 +36,6 @@ dependencies {
     implementation Dep.Firebase.auth
 
     api Dep.AndroidX.lifecycleExtensions
-    api Dep.AndroidX.Navigation.runtimeKtx
     api Dep.AndroidX.activityKtx
     api Dep.AndroidX.fragmentKtx
     api Dep.AndroidX.coreKtx

--- a/corecomponent/androidtestcomponent/build.gradle
+++ b/corecomponent/androidtestcomponent/build.gradle
@@ -2,7 +2,7 @@ import dependencies.Dep
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -3,7 +3,7 @@ import dependencies.Dep
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -9,8 +9,7 @@ import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
-import androidx.navigation.fragment.findNavController
-import com.google.android.material.internal.ViewUtils.doOnApplyWindowInsets
+import androidx.navigation.Navigation
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -78,9 +77,9 @@ class AboutFragment : DaggerFragment() {
         }.apply {
             loading = true
         }
-        binding.staffs.setOnClickListener {
-            findNavController().navigate(AboutFragmentDirections.actionAboutToStaffs())
-        }
+        binding.staffs.setOnClickListener(
+            Navigation.createNavigateOnClickListener(AboutFragmentDirections.actionAboutToStaffs())
+        )
         // TODO: Add AboutUI into RecyclerView
     }
 }

--- a/feature/announcement/build.gradle
+++ b/feature/announcement/build.gradle
@@ -3,7 +3,7 @@ import dependencies.Dep
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true

--- a/feature/contributor/build.gradle
+++ b/feature/contributor/build.gradle
@@ -4,7 +4,7 @@ import dependencies.Versions
 apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android-dynamic-module.gradle')
 

--- a/feature/preference/build.gradle
+++ b/feature/preference/build.gradle
@@ -4,7 +4,7 @@ import dependencies.Versions
 apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android-dynamic-module.gradle')
 

--- a/feature/session/build.gradle
+++ b/feature/session/build.gradle
@@ -3,7 +3,7 @@ import dependencies.Dep
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -26,7 +26,7 @@ import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.model.SessionPage
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentMainSessionsBinding
-import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.actionSessionToSearchSessions
+import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.Companion.actionSessionToSearchSessions
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
@@ -100,9 +100,7 @@ class MainSessionsFragment : DaggerFragment() {
 
             override fun createFragment(position: Int): Fragment {
                return SessionsFragment.newInstance(
-                    SessionsFragmentArgs
-                        .Builder(position)
-                        .build()
+                    SessionsFragmentArgs(position)
                 )
             }
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -45,8 +45,8 @@ import io.github.droidkaigi.confsched2020.model.defaultLang
 import io.github.droidkaigi.confsched2020.model.defaultTimeZoneOffset
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentSessionDetailBinding
-import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.actionSessionToSpeaker
-import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.actionSessionToSurvey
+import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSpeaker
+import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSurvey
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionDetailViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -242,9 +242,7 @@ class SessionsFragment : DaggerFragment() {
         val fragment: Fragment = when (tab) {
             is SessionPage.Day -> {
                 BottomSheetDaySessionsFragment.newInstance(
-                    BottomSheetDaySessionsFragmentArgs
-                        .Builder(tab.day)
-                        .build()
+                    BottomSheetDaySessionsFragmentArgs(tab.day)
                 )
             }
             SessionPage.Favorite -> {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
@@ -30,8 +30,8 @@ import io.github.droidkaigi.confsched2020.model.SpeechSession
 import io.github.droidkaigi.confsched2020.model.defaultLang
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionBinding
-import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.actionSessionToSessionDetail
-import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.actionSessionToSpeaker
+import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.Companion.actionSessionToSessionDetail
+import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirections.Companion.actionSessionToSpeaker
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.util.lazyWithParam
 import kotlin.math.max

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerItem.kt
@@ -19,7 +19,7 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Speaker
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSpeakerBinding
-import io.github.droidkaigi.confsched2020.session.ui.SearchSessionsFragmentDirections.actionSessionToSpeaker
+import io.github.droidkaigi.confsched2020.session.ui.SearchSessionsFragmentDirections.Companion.actionSessionToSpeaker
 
 class SpeakerItem @AssistedInject constructor(
     @Assisted val speaker: Speaker,

--- a/feature/session_survey/build.gradle
+++ b/feature/session_survey/build.gradle
@@ -3,7 +3,7 @@ import dependencies.Dep
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true

--- a/feature/sponsor/build.gradle
+++ b/feature/sponsor/build.gradle
@@ -3,7 +3,7 @@ import dependencies.Dep
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/LargeSponsorItem.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/LargeSponsorItem.kt
@@ -11,7 +11,7 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Sponsor
 import io.github.droidkaigi.confsched2020.sponsor.R
 import io.github.droidkaigi.confsched2020.sponsor.databinding.ItemSponsorLargeBinding
-import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.actionSponsorsToChrome
+import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.Companion.actionSponsorsToChrome
 
 class LargeSponsorItem @AssistedInject constructor(
     @Assisted private val sponsor: Sponsor,

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/SponsorItem.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/SponsorItem.kt
@@ -11,7 +11,7 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Sponsor
 import io.github.droidkaigi.confsched2020.sponsor.R
 import io.github.droidkaigi.confsched2020.sponsor.databinding.ItemSponsorBinding
-import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.actionSponsorsToChrome
+import io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragmentDirections.Companion.actionSponsorsToChrome
 
 class SponsorItem @AssistedInject constructor(
     @Assisted private val sponsor: Sponsor,

--- a/feature/staff/build.gradle
+++ b/feature/staff/build.gradle
@@ -4,7 +4,7 @@ import dependencies.Versions
 apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android-dynamic-module.gradle')
 

--- a/feature/system/build.gradle
+++ b/feature/system/build.gradle
@@ -4,7 +4,7 @@ import dependencies.Versions
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'androidx.navigation.safeargs'
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 apply from: rootProject.file('gradle/android-dynamic-module.gradle')
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Updated versions about navigation component
- Deleted unused libraries
    - If full kotlin project, we can use only ktx libraries
- To use `safe args kotlin`, generated codes are changed to kotlin codes.
- Try to use navigation method on click event for navigating to staffs
    - What I was doing was the same as before...

## Links
- https://developer.android.com/guide/navigation/navigation-getting-started
- https://developer.android.com/guide/navigation/navigation-navigate

## Screenshot
Generated codes


by Java | by Kotlin
:--: | :--:
<img src="https://user-images.githubusercontent.com/27717556/72657582-72898600-39e9-11ea-8625-2db9d47e2027.png" width="300" /> | <img src="https://user-images.githubusercontent.com/27717556/72657514-a0ba9600-39e8-11ea-98fc-dff7036b8fda.png" width="300" />

