### PR TITLE
Improve position of progress bar in session details.

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -29,6 +29,13 @@
         tools:theme="@style/Theme.DroidKaigi"
         >
 
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            />
+
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -41,16 +48,6 @@
                 android:layout_marginTop="18dp"
                 android:layout_marginBottom="18dp"
                 >
-
-                <ProgressBar
-                    android:id="@+id/progress_bar"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    />
 
                 <androidx.constraintlayout.widget.Guideline
                     android:id="@+id/guideline_start"


### PR DESCRIPTION
## Issue
- close #305

## Overview (Required)
- Put progress bar center and outside of base layout view group in session details.

## Screenshot
#### Before
case1 | case2
:--:|:--:
<img src="https://user-images.githubusercontent.com/27717556/72531180-4a4c3b00-38b4-11ea-8d5a-8c6cd2f90d8f.png" width="300" /> | <img src="https://user-images.githubusercontent.com/27717556/72531181-4a4c3b00-38b4-11ea-937d-84394c8c46da.png" width="300" />
#### After
case1 | case2
:--:|:--:
<img src="https://user-images.githubusercontent.com/34018372/72656145-b88c1d00-39dc-11ea-9127-3f03d5a70bae.png" width="300" /> | <img src="https://user-images.githubusercontent.com/34018372/72656143-b6c25980-39dc-11ea-9b4f-acfd1f4b337b.png" width="300" />


