### PR TITLE
Add ViewModel test for session search screen 

### DIFF
--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
@@ -1,20 +1,128 @@
 package io.github.droidkaigi.confsched2020.session.ui.viewmodel
 
+import com.jraska.livedata.test
+import io.github.droidkaigi.confsched2020.model.repository.SessionRepository
+import io.github.droidkaigi.confsched2020.widget.component.MockkRule
+import io.github.droidkaigi.confsched2020.widget.component.ViewModelTestRule
+import io.kotlintest.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 
 import org.junit.Assert.*
+import org.junit.Rule
 
 class SearchSessionsViewModelTest {
+    @get:Rule val viewModelTestRule = ViewModelTestRule()
+    @get:Rule val mockkRule = MockkRule(this)
+    @MockK(relaxed = true) lateinit var sessionRepository: SessionRepository
 
     @Test
-    fun getUiModel() {
+    fun load() {
+        coEvery { sessionRepository.sessionContents() } returns flowOf(Dummies.sessionContents)
+        val searchSessionViewModel = SearchSessionsViewModel(
+            sessionRepository = sessionRepository
+        )
+
+        val testObserver = searchSessionViewModel
+            .uiModel
+            .test()
+
+        val valueHistory = testObserver.valueHistory()
+
+        valueHistory[0] shouldBe SearchSessionsViewModel.UiModel.EMPTY
+        valueHistory[1].apply {
+            searchResult.sessions shouldBe Dummies.sessionContents.sessions
+            searchResult.speakers shouldBe Dummies.sessionContents.speakers
+            searchResult.query shouldBe ""
+        }
+
     }
 
     @Test
-    fun updateSearchQuery() {
+    fun searchSession_notFound() {
+        coEvery { sessionRepository.sessionContents() } returns flowOf(Dummies.sessionContents)
+        val searchSessionViewModel = SearchSessionsViewModel(
+            sessionRepository = sessionRepository
+        )
+
+        val testObserver = searchSessionViewModel
+            .uiModel
+            .test()
+
+        searchSessionViewModel.updateSearchQuery("hoge")
+
+        val valueHistory = testObserver.valueHistory()
+        valueHistory[0] shouldBe SearchSessionsViewModel.UiModel.EMPTY
+        valueHistory[1].apply {
+            searchResult.sessions shouldBe Dummies.sessionContents.sessions
+            searchResult.speakers shouldBe Dummies.sessionContents.speakers
+            searchResult.query shouldBe ""
+        }
+        valueHistory[2].apply {
+            searchResult.sessions shouldBe Dummies.sessionContents.sessions
+            searchResult.speakers shouldBe Dummies.sessionContents.speakers
+            searchResult.query shouldBe ""
+        }
+        valueHistory[3].apply {
+            searchResult.sessions shouldBe listOf()
+            searchResult.speakers shouldBe listOf()
+            searchResult.query shouldBe "hoge"
+        }
+
     }
 
     @Test
-    fun getSessionRepository() {
+    fun searchSession_Found() {
+        coEvery { sessionRepository.sessionContents() } returns flowOf(Dummies.sessionContents)
+        val searchSessionViewModel = SearchSessionsViewModel(
+            sessionRepository = sessionRepository
+        )
+
+        val testObserver = searchSessionViewModel
+            .uiModel
+            .test()
+
+        searchSessionViewModel.updateSearchQuery("DroidKaigi")
+        searchSessionViewModel.updateSearchQuery("droidKaigi")
+        searchSessionViewModel.updateSearchQuery("Keynote")
+        searchSessionViewModel.updateSearchQuery("speaker")
+
+        val valueHistory = testObserver.valueHistory()
+        valueHistory[0] shouldBe SearchSessionsViewModel.UiModel.EMPTY
+        valueHistory[1].apply {
+            searchResult.sessions shouldBe Dummies.sessionContents.sessions
+            searchResult.speakers shouldBe Dummies.sessionContents.speakers
+            searchResult.query shouldBe ""
+        }
+        valueHistory[2].apply {
+            searchResult.sessions shouldBe Dummies.sessionContents.sessions
+            searchResult.speakers shouldBe Dummies.sessionContents.speakers
+            searchResult.query shouldBe ""
+        }
+        valueHistory[3].apply {
+            searchResult.sessions shouldBe listOf(Dummies.speachSession1)
+            searchResult.speakers shouldBe listOf()
+            searchResult.query shouldBe "DroidKaigi"
+        }
+        valueHistory[4].apply {
+            searchResult.sessions shouldBe listOf(Dummies.speachSession1)
+            searchResult.speakers shouldBe listOf()
+            searchResult.query shouldBe "droidKaigi"
+        }
+        valueHistory[5].apply {
+            searchResult.sessions shouldBe listOf(Dummies.serviceSession)
+            searchResult.speakers shouldBe listOf()
+            searchResult.query shouldBe "Keynote"
+        }
+        valueHistory[6].apply {
+            searchResult.sessions shouldBe listOf(Dummies.speachSession1)
+            searchResult.speakers shouldBe Dummies.speakers
+            searchResult.query shouldBe "speaker"
+        }
+
     }
 }

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
@@ -6,13 +6,9 @@ import io.github.droidkaigi.confsched2020.widget.component.MockkRule
 import io.github.droidkaigi.confsched2020.widget.component.ViewModelTestRule
 import io.kotlintest.shouldBe
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
-
-import org.junit.Assert.*
 import org.junit.Rule
 
 class SearchSessionsViewModelTest {

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SearchSessionsViewModelTest.kt
@@ -1,0 +1,20 @@
+package io.github.droidkaigi.confsched2020.session.ui.viewmodel
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class SearchSessionsViewModelTest {
+
+    @Test
+    fun getUiModel() {
+    }
+
+    @Test
+    fun updateSearchQuery() {
+    }
+
+    @Test
+    fun getSessionRepository() {
+    }
+}


### PR DESCRIPTION
## Issue
https://github.com/DroidKaigi/conference-app-2020/issues/155

## Overview (Required)
- Add SearchSessionsViewModel Unit Test.

## Links
- N/A

## Screenshot
- N/A
