### PR TITLE
Make favorite icon state update right away when clicked

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.session.ui.item
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -61,7 +62,7 @@ class SessionItem @AssistedInject constructor(
                 favorite.isSelected = !favorite.isSelected
                 sessionsViewModel.favorite(session)
             }
-            favorite.isSelected = session.isFavorited
+            bindFavorite(session.isFavorited, favorite)
             root.setOnClickListener {
                 root.findNavController().navigate(actionSessionToSessionDetail(session.id))
             }
@@ -72,6 +73,31 @@ class SessionItem @AssistedInject constructor(
             imageRequestDisposables.clear()
             speakers.bindSpeaker()
         }
+    }
+
+    override fun bind(
+        viewBinding: ItemSessionBinding,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            bind(viewBinding, position)
+        } else {
+            payloads.distinct().forEach { payload ->
+                when (payload) {
+                    is ItemPayload.FavoritePayload -> {
+                        bindFavorite(payload.isFavorited, viewBinding.favorite)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun bindFavorite(
+        isFavorited: Boolean,
+        imageButton: ImageButton
+    ) {
+        imageButton.isSelected = isFavorited
     }
 
     private fun ViewGroup.bindSpeaker() {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2020.session.ui.item
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
@@ -57,52 +56,22 @@ class SessionItem @AssistedInject constructor(
     override fun getLayout(): Int = R.layout.item_session
 
     override fun bind(viewBinding: ItemSessionBinding, position: Int) {
-        viewBinding.favorite.setOnClickListener {
-            sessionsViewModel
-                .favorite(session)
-        }
-        bindFavorite(session.isFavorited, viewBinding.favorite)
-        viewBinding.root.setOnClickListener {
-            viewBinding.root.findNavController()
-                .navigate(actionSessionToSessionDetail(session.id))
-        }
-        viewBinding.live.isVisible = session.isOnGoing
-        viewBinding.title.text = session.title.ja
-        viewBinding.room.text = session.room.name.getByLang(defaultLang())
-        viewBinding.survey.isEnabled = session.isFinished
-        imageRequestDisposables.clear()
-        viewBinding.speakers.bindSpeaker()
-    }
-
-    override fun bind(
-        viewBinding: ItemSessionBinding,
-        position: Int,
-        payloads: MutableList<Any>
-    ) {
-        if (payloads.isEmpty()) {
-            bind(viewBinding, position)
-        } else {
-            payloads.distinct().forEach { payload ->
-                when (payload) {
-                    is ItemPayload.FavoritePayload -> {
-                        bindFavorite(payload.isFavorited, viewBinding.favorite)
-                    }
-                }
+        with(viewBinding) {
+            favorite.setOnClickListener {
+                favorite.isSelected = !favorite.isSelected
+                sessionsViewModel.favorite(session)
             }
-        }
-    }
-
-    private fun bindFavorite(
-        isFavorited: Boolean,
-        imageButton: ImageButton
-    ) {
-        imageButton.setImageResource(
-            if (isFavorited) {
-                R.drawable.ic_bookmark_black_24dp
-            } else {
-                R.drawable.ic_bookmark_border_black_24dp
+            favorite.isSelected = session.isFavorited
+            root.setOnClickListener {
+                root.findNavController().navigate(actionSessionToSessionDetail(session.id))
             }
-        )
+            live.isVisible = session.isOnGoing
+            title.text = session.title.ja
+            room.text = session.room.name.getByLang(defaultLang())
+            survey.isEnabled = session.isFinished
+            imageRequestDisposables.clear()
+            speakers.bindSpeaker()
+        }
     }
 
     private fun ViewGroup.bindSpeaker() {

--- a/feature/session/src/main/res/drawable/favorite_button_selector.xml
+++ b/feature/session/src/main/res/drawable/favorite_button_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_bookmark_black_24dp" android:state_selected="true" />
+    <item android:drawable="@drawable/ic_bookmark_border_black_24dp" />
+</selector>

--- a/feature/session/src/main/res/layout/item_session.xml
+++ b/feature/session/src/main/res/layout/item_session.xml
@@ -65,7 +65,7 @@
             android:layout_height="wrap_content"
             android:background="?selectableItemBackgroundBorderless"
             android:padding="8dp"
-            android:src="@drawable/ic_bookmark_border_black_24dp"
+            android:src="@drawable/favorite_button_selector"
             android:tint="?colorSecondary"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## Issue
- close #122 

## Overview (Required)
- Make favorite icon sync updated instead of async after update call.
- Utilized icon selector to update the favorite icon state.
- Minor cosmetic clean up.


## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/72200711-fe525e00-348f-11ea-9994-38a87fae9c6c.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/73175/72662485-fcd0ea80-39e7-11ea-8597-3ea3dcaddbcb.gif" width="300" />
