### PR TITLE
Tint BottomSheet expand icon to see it easily when app running on dark theme

### DIFF
--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
@@ -62,6 +62,7 @@
             app:layout_constraintBottom_toBottomOf="@id/start_filter"
             app:layout_constraintEnd_toEndOf="@id/start_filter"
             app:layout_constraintTop_toTopOf="@id/start_filter"
+            app:tint="?attr/colorPrimary"
             />
 
         <View


### PR DESCRIPTION
## Issue
- close #396 

## Overview (Required)
- Set `app:tint` to BottomSheet expand icon ImageView to see it easily when app running on dark theme

## Links
-

## Screenshot

Pixel 3a emulator, API 28

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/4849408/72663350-09c7fb00-3a35-11ea-8c45-697d590be327.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4849408/72663330-d7b69900-3a34-11ea-8b8b-f28a08e6baa3.png" width="300" />
<img src="https://user-images.githubusercontent.com/4849408/72663367-6b886500-3a35-11ea-8b3a-53ecc15e7591.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4849408/72663370-7216dc80-3a35-11ea-9706-2f6f380a7000.png" width="300" />
