### PR TITLE
Fix display conditions issue of my plan's empty session view

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -113,7 +113,8 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
             groupAdapter.update(sessions.map {
                 sessionItemFactory.create(it, sessionsViewModel)
             })
-            binding.isEmptySessions = count <= 0
+            val favoritedSessionsCount = sessions.count()
+            binding.isEmptySessions = favoritedSessionsCount <= 0
         }
     }
 


### PR DESCRIPTION
## Issue
- close #394 

## Overview (Required)
- The display conditions of EmptyView on My Plan depended on the number of speaker sessions added to favorites. 
- Simply changed to depend on the number of items added to favorites

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/18392939/72664332-ec4c5e80-3a3f-11ea-8583-9e63c1be8d9d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/18392939/72664301-9aa3d400-3a3f-11ea-9faa-5eedda41d889.png" width="300" />
