### PR TITLE
Use SharedElementTransition when transitioning to the Speaker screen

### DIFF
--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -112,6 +112,10 @@
             android:name="speakerId"
             app:argType="io.github.droidkaigi.confsched2020.model.SpeakerId"
             />
+        <argument
+            android:name="transitionNameSuffix"
+            app:argType="string"
+            />
 
         <action
             android:id="@+id/action_speaker_to_session_detail"

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.TextPaint
@@ -10,19 +9,21 @@ import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.view.doOnPreDraw
+import androidx.annotation.IdRes
 import androidx.core.content.ContextCompat
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
 import androidx.core.text.inSpans
-import androidx.annotation.IdRes
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
 import androidx.navigation.NavOptions
+import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.transition.TransitionManager
@@ -75,6 +76,10 @@ class SessionDetailFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
     private var showEllipsis = true
+
+    companion object {
+        private const val TRANSITION_NAME_SUFFIX = "detail"
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -219,24 +224,30 @@ class SessionDetailFragment : DaggerFragment() {
             val speakerView = layoutInflater.inflate(
                 R.layout.layout_speaker, this, false
             ) as ViewGroup
+            val speakerNameView = speakerView.findViewById<TextView>(R.id.speaker)
+            val speakerImageView = speakerView.findViewById<ImageView>(R.id.speaker_image)
+            speakerImageView.transitionName = "${speaker.id}-${TRANSITION_NAME_SUFFIX}"
             speakerView.setOnClickListener {
-                findNavController().navigate(actionSessionToSpeaker(speaker.id))
+                val extras = FragmentNavigatorExtras(
+                    speakerImageView to speakerImageView.transitionName
+                )
+                findNavController()
+                    .navigate(actionSessionToSpeaker(speaker.id, TRANSITION_NAME_SUFFIX), extras)
             }
-            val textView: TextView = speakerView.findViewById(R.id.speaker)
-            bindSpeakerData(speaker, textView)
-
+            bindSpeakerData(speaker, speakerNameView, speakerImageView)
             addView(speakerView)
         }
     }
 
     private fun bindSpeakerData(
         speaker: Speaker,
-        textView: TextView
+        speakerNameView: TextView,
+        speakerImageView: ImageView
     ) {
-        textView.text = speaker.name
+        speakerNameView.text = speaker.name
 //        setHighlightText(textView, query)
         val imageUrl = speaker.imageUrl
-        val context = textView.context
+        val context = speakerNameView.context
         val placeHolder = run {
             VectorDrawableCompat.create(
                 context.resources,
@@ -248,7 +259,7 @@ class SessionDetailFragment : DaggerFragment() {
                 )
             }
         }?.also {
-            textView.setLeftDrawable(it)
+            speakerImageView.setImageDrawable(it)
         }
 
         Coil.load(context, imageUrl) {
@@ -257,21 +268,9 @@ class SessionDetailFragment : DaggerFragment() {
             transformations(CircleCropTransformation())
             lifecycle(viewLifecycleOwner)
             target {
-                textView.setLeftDrawable(it)
+                speakerImageView.setImageDrawable(it)
             }
         }
-    }
-
-    private fun TextView.setLeftDrawable(drawable: Drawable) {
-        val res = context.resources
-        val widthDp = 32
-        val heightDp = 32
-        val widthPx = (widthDp * res.displayMetrics.density).toInt()
-        val heightPx = (heightDp * res.displayMetrics.density).toInt()
-        drawable.setBounds(0, 0, widthPx, heightPx)
-        setCompoundDrawables(
-            drawable, null, null, null
-        )
     }
 }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
@@ -11,6 +12,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.navArgs
+import androidx.transition.TransitionInflater
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
@@ -42,6 +44,14 @@ class SpeakerFragment : DaggerFragment() {
     private val navArgs: SpeakerFragmentArgs by navArgs()
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        sharedElementEnterTransition = TransitionInflater.from(requireContext())
+            .inflateTransition(android.R.transition.move).apply {
+                interpolator = AccelerateDecelerateInterpolator()
+            }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -58,6 +68,7 @@ class SpeakerFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        postponeEnterTransition()
         progressTimeLatch = ProgressTimeLatch { showProgress ->
             binding.progressBar.isVisible = showProgress
         }.apply {
@@ -74,8 +85,9 @@ class SpeakerFragment : DaggerFragment() {
                 val sessions = uiModel.sessions.takeIf { it.isNotEmpty() } ?: return@observe
 
                 groupAdapter.update(
-                    listOf(speakerDetailItemFactory.create(speaker)) +
-                        sessions.map { speakerSessionItemFactory.create(it) }
+                    listOf(speakerDetailItemFactory.create(speaker, navArgs.transitionNameSuffix) {
+                        startPostponedEnterTransition()
+                    }) + sessions.map { speakerSessionItemFactory.create(it) }
                 )
             }
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
@@ -5,21 +5,23 @@ import android.text.method.LinkMovementMethod
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import coil.Coil
 import coil.api.load
-import coil.request.RequestDisposable
 import coil.transform.CircleCropTransformation
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.databinding.BindableItem
-import com.xwray.groupie.databinding.ViewHolder
 import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Speaker
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSpeakerDetailBinding
+import javax.inject.Named
 
 class SpeakerDetailItem @AssistedInject constructor(
     @Assisted val speaker: Speaker,
+    @Assisted @Named("transitionNameSuffix") val transitionNameSuffix: String,
+    @Assisted val onImageLoadedCallback: () -> Unit,
     private val context: Context,
     private val lifecycleOwnerLiveData: LiveData<LifecycleOwner>
 ) : BindableItem<ItemSpeakerDetailBinding>(speaker.id.hashCode().toLong()),
@@ -41,12 +43,19 @@ class SpeakerDetailItem @AssistedInject constructor(
         viewBinding.speaker = speaker
 
         viewBinding.speakerDescription.movementMethod = LinkMovementMethod.getInstance()
+        viewBinding.speakerImage.transitionName = "${speaker.id}-${transitionNameSuffix}"
 
-        viewBinding.speakerImage.load(speaker.imageUrl) {
+        speaker.imageUrl ?: onImageLoadedCallback()
+
+        Coil.load(context, speaker.imageUrl) {
             crossfade(true)
             placeholder(placeHolder)
             transformations(CircleCropTransformation())
             lifecycle(lifecycleOwnerLiveData.value)
+            target {
+                viewBinding.speakerImage.setImageDrawable(it)
+                onImageLoadedCallback()
+            }
         }
     }
 
@@ -65,7 +74,9 @@ class SpeakerDetailItem @AssistedInject constructor(
     @AssistedInject.Factory
     interface Factory {
         fun create(
-            speaker: Speaker
+            speaker: Speaker,
+            @Named("transitionNameSuffix") transitionNameSuffix: String,
+            onImageLoadedCallback: () -> Unit
         ): SpeakerDetailItem
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerItem.kt
@@ -1,11 +1,10 @@
 package io.github.droidkaigi.confsched2020.session.ui.item
 
-import android.graphics.drawable.Drawable
-import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.Coil
 import coil.api.load
@@ -29,14 +28,22 @@ class SpeakerItem @AssistedInject constructor(
 
     private val imageRequestDisposables = mutableListOf<RequestDisposable>()
 
+    companion object {
+        private const val TRANSITION_NAME_SUFFIX = "speaker"
+    }
+
     override fun getLayout(): Int = R.layout.item_speaker
 
     override fun bind(viewBinding: ItemSpeakerBinding, position: Int) {
         viewBinding.root.setOnClickListener {
+            val extras = FragmentNavigatorExtras(
+                viewBinding.image to viewBinding.image.transitionName
+            )
             viewBinding.root.findNavController()
-                .navigate(actionSessionToSpeaker(speaker.id))
+                .navigate(actionSessionToSpeaker(speaker.id, TRANSITION_NAME_SUFFIX), extras)
         }
         viewBinding.name.text = speaker.name
+        viewBinding.image.transitionName = "${speaker.id}-${TRANSITION_NAME_SUFFIX}"
 
         imageRequestDisposables.clear()
         val imageUrl = speaker.imageUrl
@@ -52,7 +59,7 @@ class SpeakerItem @AssistedInject constructor(
                 )
             }
         }?.also {
-            viewBinding.name.setLeftDrawable(it)
+            viewBinding.image.setImageDrawable(it)
         }
 
         imageRequestDisposables += Coil.load(context, imageUrl) {
@@ -61,7 +68,7 @@ class SpeakerItem @AssistedInject constructor(
             transformations(CircleCropTransformation())
             lifecycle(lifecycleOwnerLiveData.value)
             target {
-                viewBinding.name.setLeftDrawable(it)
+                viewBinding.image.setImageDrawable(it)
             }
         }
     }
@@ -69,18 +76,6 @@ class SpeakerItem @AssistedInject constructor(
     override fun unbind(viewHolder: ViewHolder<ItemSpeakerBinding>) {
         super.unbind(viewHolder)
         imageRequestDisposables.forEach { it.dispose() }
-    }
-
-    private fun TextView.setLeftDrawable(drawable: Drawable) {
-        val res = context.resources
-        val widthDp = 64
-        val heightDp = 64
-        val widthPx = (widthDp * res.displayMetrics.density).toInt()
-        val heightPx = (heightDp * res.displayMetrics.density).toInt()
-        drawable.setBounds(0, 0, widthPx, heightPx)
-        setCompoundDrawables(
-            drawable, null, null, null
-        )
     }
 
     override fun providerEqualableContents(): Array<*> {

--- a/feature/session/src/main/res/layout/item_speaker.xml
+++ b/feature/session/src/main/res/layout/item_speaker.xml
@@ -30,20 +30,29 @@
             app:layout_constraintGuide_end="8dp"
             />
 
+        <ImageView
+            android:id="@+id/image"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:background="@drawable/ic_person_outline_black_32dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/guideline_start"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
         <TextView
             android:id="@+id/name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="32dp"
-            android:drawableStart="@drawable/ic_person_outline_black_32dp"
-            android:drawablePadding="8dp"
+            android:paddingStart="8dp"
             android:gravity="center_vertical|start"
             android:singleLine="false"
             android:textAppearance="?attr/textAppearanceBody2"
             android:textColor="@color/speaker_name"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
-            app:layout_constraintStart_toStartOf="@id/guideline_start"
+            app:layout_constraintStart_toEndOf="@+id/image"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="speaker name"
             />

--- a/feature/session/src/main/res/layout/layout_speaker.xml
+++ b/feature/session/src/main/res/layout/layout_speaker.xml
@@ -7,12 +7,17 @@
     android:layout_height="wrap_content"
     >
 
+    <ImageView
+        android:id="@+id/speaker_image"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:background="@drawable/ic_person_outline_black_32dp"/>
+
     <TextView
         android:id="@+id/speaker"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="32dp"
-        android:drawableStart="@drawable/ic_person_outline_black_32dp"
-        android:drawablePadding="8dp"
+        android:paddingStart="8dp"
         android:paddingEnd="16dp"
         android:gravity="center_vertical"
         android:textAppearance="?attr/textAppearanceCaption"


### PR DESCRIPTION
## Issue
- close #168

## Overview (Required)
- Apply SharedElementTransition to speaker image
- Also I tried to apply "return shared element" for SpeakerFragment to SessionDetailFragment transition.
  - It was difficult to apply return shared element to other transitions.

## Links
-

## Screenshot
||Before | After
|---|:--: | :--:
|Main to Speaker|<img src="https://user-images.githubusercontent.com/32016001/72664660-d2ad1600-3a43-11ea-820b-a9ea8d2ab615.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/32016001/72664450-5f0a0980-3a41-11ea-9675-45a0c86f82e7.gif" width="300" />
|Search to Speaker|<img src="https://user-images.githubusercontent.com/32016001/72664539-8b725580-3a42-11ea-93ee-9ab92baab357.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/32016001/72664606-50245680-3a43-11ea-961f-ca962fd75f76.gif" width="300" />
|Session Detail to Speaker|<img src="https://user-images.githubusercontent.com/32016001/72664549-c07ea800-3a42-11ea-9f5d-cde6c7c78319.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/32016001/72664480-cf188f80-3a41-11ea-9d95-8da3651d1825.gif" width="300" />
