### PR TITLE
Fix options menu not shown when rotate

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -106,6 +106,7 @@ class MainActivity : DaggerAppCompatActivity() {
             view.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = insets.systemWindowInsetTop + initialState.margins.top
             }
+            // Invalidate because option menu cannot be displayed after screen rotation
             invalidateOptionsMenu()
         }
         binding.navView.doOnApplyWindowInsets { view, insets, initialState ->

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020
 
 import android.annotation.SuppressLint
-import android.content.res.Configuration
 import android.os.Bundle
-import android.view.Menu
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -1,7 +1,9 @@
 package io.github.droidkaigi.confsched2020
 
 import android.annotation.SuppressLint
+import android.content.res.Configuration
 import android.os.Bundle
+import android.view.Menu
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.appcompat.content.res.AppCompatResources
@@ -106,6 +108,7 @@ class MainActivity : DaggerAppCompatActivity() {
             view.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = insets.systemWindowInsetTop + initialState.margins.top
             }
+            invalidateOptionsMenu()
         }
         binding.navView.doOnApplyWindowInsets { view, insets, initialState ->
             view.apply {


### PR DESCRIPTION
## Issue
- close #388

## Overview (Required)
- Fix bug that options menu not shown when the screen is rotated.
  - Investigate by the layout inspector, OptionsMenu was drawn. But, it's position was wrong.Call `invalidateOptionsMenu()` when `doOnApplyWindowInsets` then it was resolve.


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12192769/72664822-bf02af00-3a45-11ea-8d57-7a17c3ff7fc8.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/12192769/72664821-bf02af00-3a45-11ea-920f-ff741b613e5f.gif" width="300" />

