### PR TITLE
Add presentation material to session detail

### DIFF
--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -102,6 +102,16 @@
             app:popEnterAnim="@anim/fade_in"
             app:popExitAnim="@anim/fade_out"
             />
+        <action
+            android:id="@+id/action_session_to_chrome"
+            app:destination="@id/chrome"
+            >
+            <argument
+                android:name="url"
+                app:argType="string"
+                app:nullable="false"
+                />
+        </action>
     </fragment>
     <fragment
         android:id="@+id/speaker"

--- a/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -3,6 +3,7 @@
     <string name="announce_label">お知らせ</string>
     <string name="map_label">フロアマップ</string>
     <string name="session_label">タイムライン</string>
+    <string name="material_label">資料</string>
     <string name="about_label">DroidKaigi とは</string>
     <string name="sponsor_label">スポンサー</string>
     <string name="survey_label">全体アンケート</string>

--- a/corecomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="session_label">Session</string>
     <!-- Speaker -->
     <string name="speaker_label" translatable="false">Speaker</string>
+    <!-- Material -->
+    <string name="material_label" translatable="false">Material</string>
     <!-- Announce -->
     <string name="announce_label">Announce</string>
     <!-- About -->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -45,6 +45,7 @@ import io.github.droidkaigi.confsched2020.model.defaultLang
 import io.github.droidkaigi.confsched2020.model.defaultTimeZoneOffset
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentSessionDetailBinding
+import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToChrome
 import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSpeaker
 import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSurvey
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
@@ -160,6 +161,7 @@ class SessionDetailFragment : DaggerFragment() {
             }
         }
         binding.speakers.bindSpeaker(session)
+        setUpMaterialData(session)
     }
 
     private fun setupSessionDescription(fullDescription: String) {
@@ -176,7 +178,8 @@ class SessionDetailFragment : DaggerFragment() {
                 textView.width - textView.paint.measureText(ellipsis),
                 TextUtils.TruncateAt.END
             )
-            val ellipsisColor = ContextCompat.getColor(requireContext(), R.color.design_default_color_secondary)
+            val ellipsisColor =
+                ContextCompat.getColor(requireContext(), R.color.design_default_color_secondary)
             val onClickListener = {
                 TransitionManager.beginDelayedTransition(binding.sessionLayout)
                 textView.text = fullDescription
@@ -262,12 +265,54 @@ class SessionDetailFragment : DaggerFragment() {
         }
     }
 
-    private fun TextView.setLeftDrawable(drawable: Drawable) {
+    private fun setUpMaterialData(session: Session) {
+        if (session is SpeechSession) {
+            session.videoUrl?.let {
+                setUpMovieView(it)
+            } ?: setUpNoMovieView()
+            session.slideUrl?.let {
+                setUpSlideView(it)
+            } ?: setUpNoSlideView()
+            return
+        }
+        setUpNoMovieView()
+        setUpNoSlideView()
+    }
+
+    private fun setUpNoMovieView() {
+        val icVideo = ContextCompat.getDrawable(requireContext(), R.drawable.ic_video_24dp)
+        icVideo?.let { binding.movie.setLeftDrawable(it, 24) }
+    }
+
+    private fun setUpMovieView(movieUrl: String) {
+        val icVideo =
+            ContextCompat.getDrawable(requireContext(), R.drawable.ic_video_light_blue_24dp)
+        icVideo?.let { binding.movie.setLeftDrawable(it, 24) }
+        binding.movie.setTextColor(ContextCompat.getColor(requireContext(), R.color.light_blue_300))
+        binding.movie.setOnClickListener {
+            findNavController().navigate(actionSessionToChrome(movieUrl))
+        }
+    }
+
+    private fun setUpNoSlideView() {
+        val icSlide = ContextCompat.getDrawable(requireContext(), R.drawable.ic_slide_24dp)
+        icSlide?.let { binding.slide.setLeftDrawable(it, 24) }
+    }
+
+    private fun setUpSlideView(slideUrl: String) {
+        val icSlide =
+            ContextCompat.getDrawable(requireContext(), R.drawable.ic_slide_light_blue_24dp)
+        icSlide?.let { binding.slide.setLeftDrawable(it, 24) }
+        binding.slide.setTextColor(ContextCompat.getColor(requireContext(), R.color.light_blue_300))
+        binding.slide.setOnClickListener {
+            findNavController().navigate(actionSessionToChrome(slideUrl))
+        }
+    }
+
+    private fun TextView.setLeftDrawable(drawable: Drawable, sizeDp: Int = 32) {
         val res = context.resources
-        val widthDp = 32
-        val heightDp = 32
-        val widthPx = (widthDp * res.displayMetrics.density).toInt()
-        val heightPx = (heightDp * res.displayMetrics.density).toInt()
+        val widthPx = (sizeDp * res.displayMetrics.density).toInt()
+        val heightPx = (sizeDp * res.displayMetrics.density).toInt()
         drawable.setBounds(0, 0, widthPx, heightPx)
         setCompoundDrawables(
             drawable, null, null, null

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.TextPaint

--- a/feature/session/src/main/res/drawable/ic_slide_24dp.xml
+++ b/feature/session/src/main/res/drawable/ic_slide_24dp.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    >
+    <path
+        android:fillColor="?android:attr/textColorSecondary"
+        android:pathData="M6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM18 14V2H6V14H18ZM9.5 9.67L11.19 11.93L13.67 8.83L17 13H7L9.5 9.67ZM0 18V4H2V18H16V20H2C0.9 20 0 19.1 0 18Z"
+        />
+</vector>

--- a/feature/session/src/main/res/drawable/ic_slide_light_blue_24dp.xml
+++ b/feature/session/src/main/res/drawable/ic_slide_light_blue_24dp.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    >
+    <path
+        android:fillColor="@color/light_blue_300"
+        android:pathData="M6 0H18C19.1 0 20 0.9 20 2V14C20 15.1 19.1 16 18 16H6C4.9 16 4 15.1 4 14V2C4 0.9 4.9 0 6 0ZM18 14V2H6V14H18ZM9.5 9.67L11.19 11.93L13.67 8.83L17 13H7L9.5 9.67ZM0 18V4H2V18H16V20H2C0.9 20 0 19.1 0 18Z"
+        />
+</vector>

--- a/feature/session/src/main/res/drawable/ic_video_24dp.xml
+++ b/feature/session/src/main/res/drawable/ic_video_24dp.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    >
+    <path
+        android:fillColor="?android:attr/textColorSecondary"
+        android:pathData="M1 0H13C13.55 0 14 0.45 14 1V4.5L18 0.5V11.5L14 7.5V11C14 11.55 13.55 12 13 12H1C0.45 12 0 11.55 0 11V1C0 0.45 0.45 0 1 0ZM12 10V2H2V10H12Z"
+        />
+</vector>

--- a/feature/session/src/main/res/drawable/ic_video_light_blue_24dp.xml
+++ b/feature/session/src/main/res/drawable/ic_video_light_blue_24dp.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    >
+    <path
+        android:fillColor="@color/light_blue_300"
+        android:pathData="M1 0H13C13.55 0 14 0.45 14 1V4.5L18 0.5V11.5L14 7.5V11C14 11.55 13.55 12 13 12H1C0.45 12 0 11.55 0 11V1C0 0.45 0.45 0 1 0ZM12 10V2H2V10H12Z"
+        />
+</vector>

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -254,10 +254,71 @@
                     android:orientation="vertical"
                     android:showDividers="middle"
                     app:isVisible="@{session.hasSpeaker}"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/speaker_title"
+                    />
+
+                <View
+                    android:id="@+id/divider_speaker_and_material"
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="28dp"
+                    android:background="@color/black_alpha_12"
+                    app:layout_constraintEnd_toEndOf="@id/guideline_end"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/speakers"
+                    />
+
+                <TextView
+                    android:id="@+id/material_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="28dp"
+                    android:text="@string/material_label"
+                    android:textAppearance="?textAppearanceSubtitle2"
+                    android:textColor="@color/session_detail_label"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/divider_speaker_and_material"
+                    />
+
+                <TextView
+                    android:id="@+id/movie"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:paddingStart="16dp"
+                    android:paddingTop="4dp"
+                    android:paddingEnd="16dp"
+                    android:paddingBottom="4dp"
+                    android:text="@string/movie"
+                    android:textAppearance="?textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/material_title"
+                    tools:text="MOVIE"
+                    />
+
+                <TextView
+                    android:id="@+id/slide"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="32dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:paddingStart="16dp"
+                    android:paddingTop="4dp"
+                    android:paddingEnd="16dp"
+                    android:paddingBottom="4dp"
+                    android:text="@string/slide"
+                    android:textAppearance="?textAppearanceCaption"
+                    android:textColor="?android:attr/textColorSecondary"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/guideline_start"
+                    app:layout_constraintTop_toBottomOf="@id/movie"
+                    tools:text="SLIDE"
                     />
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/session/src/main/res/values-jp/strings.xml
+++ b/feature/session/src/main/res/values-jp/strings.xml
@@ -9,5 +9,6 @@
     <string name="speaker">スピーカー</string>
     <string name="session">セッション</string>
     <string name="query_hint">検索する</string>
+    <string name="slide">スライド</string>
     <string name="empty_favorite_session">お気に入りのセッションを登録すると\nあなた専用のプランを作ることが\nできます。</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -16,5 +16,7 @@
     <string name="speaker">Speaker</string>
     <string name="session">Session</string>
     <string name="query_hint">Search</string>
+    <string name="movie" translatable="false">MOVIE</string>
+    <string name="slide">SLIDE</string>
     <string name="empty_favorite_session">You choose your favorite sessions, then you can make a plan for you.</string>
 </resources>


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2020/issues/164

## Overview (Required)
- Display a disabled link even if there is no material yet.
- Display a link if there is material.

## Screenshot
Before | no material | no material dark | has material | has material dark 
:--: | :--: | :--: | :--: | :--: 
<img src="https://user-images.githubusercontent.com/2410843/72665187-1ce4c600-3a49-11ea-8a9f-99271ed28aed.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2410843/72665079-8d3f1780-3a48-11ea-9dc7-dc6a27f6d431.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2410843/72665086-9af49d00-3a48-11ea-9b0b-a0c7a5fd6708.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2410843/72665121-b2cc2100-3a48-11ea-99a9-fd5a8d3f4e99.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2410843/72665126-c5465a80-3a48-11ea-811d-f5a9aa0bf816.png" width="300" />

