### PR TITLE
Tint MY PLAN's BottomSheet expand icon to see it easily when app running on dark theme

### DIFF
--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
@@ -68,7 +68,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical|end"
                 android:layout_marginEnd="8dp"
-                android:src="@drawable/ic_expand_less_12dp" />
+                android:src="@drawable/ic_expand_less_12dp"
+                app:tint="?attr/colorPrimary" />
         </FrameLayout>
 
         <View


### PR DESCRIPTION
## Issue
- close #406 
- related #396 

## Overview (Required)
- Set `app:tint` to MY PLAN's BottomSheet expand icon ImageView to see it easily when app running on dark theme
- DAY1 and DAY2's BottomSheet expand icon had already fixed on #399 

## Links
-

## Screenshot

Pixel 3a emulator, API 28

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/4849408/72665404-849c1080-3a4b-11ea-971d-91cf5579c95a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4849408/72665409-91206900-3a4b-11ea-93e5-7bfd06145f6f.png" width="300" />
<img src="https://user-images.githubusercontent.com/4849408/72665420-abf2dd80-3a4b-11ea-9b88-4d1e302e1785.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4849408/72665426-b57c4580-3a4b-11ea-9df9-41e169a9f04a.png" width="300" />