### PR TITLE
Apply speaker item's design in session detail screen

### DIFF
--- a/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -11,6 +11,8 @@
     <string name="description_filter_applied">フィルター%1$sを適用</string>
     <string name="description_filter_not_applied">フィルター%1$sを解除</string>
     <string name="staffs_label">スタッフリスト</string>
+    <!-- Speaker -->
+    <string name="speaker_label">スピーカー</string>
     <!-- Notification -->
     <string name="notification_title_session_start">マイセッション開始のお知らせ</string>
     <string name="notification_message_session_title">%1$s がもうすぐ始まります。</string>

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -217,7 +217,7 @@ class SessionDetailFragment : DaggerFragment() {
             val speaker: Speaker =
                 (session as? SpeechSession)?.speakers?.getOrNull(index) ?: return@forEach
             val speakerView = layoutInflater.inflate(
-                R.layout.layout_speaker, this, false
+                R.layout.layout_speaker_session_detail, this, false
             ) as ViewGroup
             speakerView.setOnClickListener {
                 findNavController().navigate(actionSessionToSpeaker(speaker.id))
@@ -264,8 +264,8 @@ class SessionDetailFragment : DaggerFragment() {
 
     private fun TextView.setLeftDrawable(drawable: Drawable) {
         val res = context.resources
-        val widthDp = 32
-        val heightDp = 32
+        val widthDp = 60
+        val heightDp = 60
         val widthPx = (widthDp * res.displayMetrics.density).toInt()
         val heightPx = (heightDp * res.displayMetrics.density).toInt()
         drawable.setBounds(0, 0, widthPx, heightPx)

--- a/feature/session/src/main/res/color-night/speaker_name_session_detail.xml
+++ b/feature/session/src/main/res/color-night/speaker_name_session_detail.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?colorSecondary" />
+</selector>

--- a/feature/session/src/main/res/color/speaker_name_session_detail.xml
+++ b/feature/session/src/main/res/color/speaker_name_session_detail.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?colorSecondary" />
+</selector>

--- a/feature/session/src/main/res/layout/layout_speaker_session_detail.xml
+++ b/feature/session/src/main/res/layout/layout_speaker_session_detail.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="?attr/selectableItemBackground"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    >
+
+    <TextView
+        android:id="@+id/speaker"
+        android:layout_width="match_parent"
+        android:layout_height="60dp"
+        android:drawableStart="@drawable/ic_person_outline_black_32dp"
+        android:drawablePadding="8dp"
+        android:paddingEnd="16dp"
+        android:gravity="center_vertical"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/speaker_name_session_detail"
+        tools:text="taka"
+        />
+</LinearLayout>

--- a/feature/session/src/main/res/layout/layout_speaker_session_detail.xml
+++ b/feature/session/src/main/res/layout/layout_speaker_session_detail.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:background="?attr/selectableItemBackground"
-    android:layout_width="match_parent"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     >
 


### PR DESCRIPTION
## Issue
- close #390 

## Overview (Required)
- String localizing
- User icon sizing(60dp)
- Speaker name sizing(textAppearanceBody2)
- Should more intuitive tap feedback like speaker layout of day's session

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/22637734/72666212-69cd9a00-3a53-11ea-9f52-9ac5bd3d16eb.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/22637734/72666216-74882f00-3a53-11ea-84df-7c1ab96ec440.jpg" width="300" />
