### PR TITLE
Enable R8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,5 @@ to_be_encrypted/
 to_be_encrypted.zip
 google-services.json
 !**/debug/google-services.json
+
+proguard-merged-config.txt

--- a/android-base/build.gradle
+++ b/android-base/build.gradle
@@ -51,9 +51,9 @@ android {
             applicationIdSuffix Packages.debugNameSuffix
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             signingConfig signingConfigs.release
-//            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     dataBinding {

--- a/android-base/proguard-rules-navigation.pro
+++ b/android-base/proguard-rules-navigation.pro
@@ -1,9 +1,0 @@
--keepnames class io.github.droidkaigi.confsched2020.model.SessionId
--keepnames class io.github.droidkaigi.confsched2020.session.ui.BottomSheetDaySessionsFragment
--keepnames class io.github.droidkaigi.confsched2020.session.ui.BottomSheetFavoriteSessionsFragment
--keepnames class io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragment
--keepnames class io.github.droidkaigi.confsched2020.session.ui.SearchSessionsFragment
--keepnames class io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragment
--keepnames class io.github.droidkaigi.confsched2020.session.ui.SessionsFragment
--keepnames class io.github.droidkaigi.confsched2020.sponsor.ui.SponsorsFragment
--keepnames class io.github.droidkaigi.confsched2020.staff.ui.StaffsFragment

--- a/android-base/proguard-rules.pro
+++ b/android-base/proguard-rules.pro
@@ -19,3 +19,41 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+## Extra
+
+# Generate merge config list
+-printconfiguration proguard-merged-config.txt
+
+## General
+
+# Do not remove annotations
+-keepattributes *Annotation*
+-keepattributes EnclosingMethod,Signature
+
+# Replace source file attributes by SourceFile to reduce the size
+# report system can de-obfuscate them
+-renamesourcefileattribute SourceFile
+# To see readable stacktraces
+-keepattributes SourceFile,LineNumberTable
+
+-dontwarn org.jetbrains.annotations.**
+
+
+# Most of volatile fields are updated with AFU and should not be mangled
+-keepclassmembernames class kotlinx.** {
+    volatile <fields>;
+}
+
+# TODO: Works but needs to be obfuscated
+-keep class io.github.droidkaigi.confsched2020.staff.** { *; }
+-keep class io.github.droidkaigi.confsched2020.contributor.** { *; }
+
+# NOTE: staff and contributor settings
+# # reflect
+# -keep class kotlin.reflect.** { *; }
+# -keep class kotlin.jvm.internal.** { *; }
+# -keep class kotlin.jvm.functions.** { *; }
+# -keep class androidx.lifecycle.ViewModel
+# -keep class androidx.fragment.app.** { *; }
+# -keep class io.github.droidkaigi.confsched2020.util.** { *; }

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -134,8 +134,8 @@ object Dep {
         val android = "com.google.dagger:dagger-android:$version"
         val androidProcessor = "com.google.dagger:dagger-android-processor:$version"
         val assistedInjectAnnotations =
-            "com.squareup.inject:assisted-inject-annotations-dagger2:0.5.0"
-        val assistedInjectProcessor = "com.squareup.inject:assisted-inject-processor-dagger2:0.5.0"
+            "com.squareup.inject:assisted-inject-annotations-dagger2:0.5.2"
+        val assistedInjectProcessor = "com.squareup.inject:assisted-inject-processor-dagger2:0.5.2"
     }
 
     object Ktor {

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -139,7 +139,7 @@ object Dep {
     }
 
     object Ktor {
-        val version = "1.3.0-beta-2"
+        val version = "1.3.0"
         val clientCommon = "io.ktor:ktor-client-core:$version"
         val clientAndroid = "io.ktor:ktor-client-okhttp:$version"
         val clientIos = "io.ktor:ktor-client-ios:$version"


### PR DESCRIPTION
## Issue
- close #249 

## Overview (Required)
- enable r8.
There are the following problems:
https://github.com/DroidKaigi/conference-app-2020/pull/411#pullrequestreview-344997116

## Links
Here is a report of the rules we set up this time.
- https://github.com/DroidKaigi/conference-app-2020/files/4082623/proguard-merged-config.txt

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
