### PR TITLE
Fix: If filter hits on MyPlan page, filter button is shown

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -80,19 +80,7 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
 
         sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
-            binding.sessionRecycler.isVisible = when (uiModel.expandFilterState) {
-                ExpandFilterState.EXPANDED, ExpandFilterState.CHANGING ->
-                    true
-                else ->
-                    false
-            }
-            binding.startFilter.visibility = when (uiModel.expandFilterState) {
-                ExpandFilterState.EXPANDED, ExpandFilterState.CHANGING ->
-                    View.VISIBLE
-                else ->
-                    View.INVISIBLE
-            }
-            binding.expandLess.isVisible = when (uiModel.expandFilterState) {
+            binding.isCollapsed = when (uiModel.expandFilterState) {
                 ExpandFilterState.COLLAPSED ->
                     true
                 else ->
@@ -109,7 +97,7 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
                 R.string.applicable_session,
                 count as Int
             )
-            binding.filteredSessionCount.isVisible = uiModel.filters.isFiltered()
+            binding.isFiltered = uiModel.filters.isFiltered()
             groupAdapter.update(sessions.map {
                 sessionItemFactory.create(it, sessionsViewModel)
             })

--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
@@ -4,6 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <variable
+            name="isCollapsed"
+            type="Boolean" />
+
+        <variable
+            name="isFiltered"
+            type="Boolean" />
 
         <variable
             name="isEmptySessions"
@@ -35,6 +42,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="@style/TextAppearance.DroidKaigi.Caption"
+            app:isHide="@{isFiltered}"
             app:icon="@drawable/ic_filter_list_black_24dp"
             app:layout_constraintBottom_toBottomOf="@id/start_filter"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
@@ -49,6 +57,7 @@
             android:text="@string/start_filter"
             android:textAppearance="@style/TextAppearance.DroidKaigi.Body2"
             app:icon="@drawable/ic_filter_list_black_24dp"
+            app:isHide="@{(!isEmptySessions || isFiltered) &amp;&amp; !isCollapsed}"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -58,6 +67,7 @@
             android:layout_height="30dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:visibility="gone"
+            app:isHide="@{isCollapsed}"
             app:layout_constraintBottom_toBottomOf="@id/start_filter"
             app:layout_constraintEnd_toEndOf="@id/start_filter"
             app:layout_constraintTop_toTopOf="@id/start_filter">
@@ -89,6 +99,7 @@
             android:orientation="vertical"
             android:paddingTop="8dp"
             app:isVisibleWithAnimation="@{!isEmptySessions}"
+            app:isHide="@{!isCollapsed}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_favorite_session.xml
@@ -49,7 +49,6 @@
             android:text="@string/start_filter"
             android:textAppearance="@style/TextAppearance.DroidKaigi.Body2"
             app:icon="@drawable/ic_filter_list_black_24dp"
-            app:isHide="@{!isEmptySessions}"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## Issue
- close #397

## Overview (Required)

- I changed the conditions for displaying the filter button.
- The filter button is displayed when (has filtered sessions || unfiltered) && close the filter.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/966751/72666407-43a8f980-3a55-11ea-9441-74657946971d.png" width="300"> | <img src="https://user-images.githubusercontent.com/966751/72666408-499eda80-3a55-11ea-8c7c-77c27964fa21.png" width="300">

