### PR TITLE
Specify layout resource on constructor of Fragment

### DIFF
--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/DaggerFragment.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/DaggerFragment.kt
@@ -1,0 +1,27 @@
+package io.github.droidkaigi.confsched2020.util
+
+import android.content.Context
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
+import dagger.android.AndroidInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+
+abstract class DaggerFragment(@LayoutRes contentLayoutId: Int = 0) :
+    Fragment(contentLayoutId),
+    HasAndroidInjector {
+
+    @Inject
+    lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+    }
+
+    override fun androidInjector(): AndroidInjector<Any> {
+        return androidInjector
+    }
+}

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -1,12 +1,9 @@
 package io.github.droidkaigi.confsched2020.about.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.Navigation
@@ -14,7 +11,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.about.R
 import io.github.droidkaigi.confsched2020.about.databinding.FragmentAboutBinding
@@ -23,12 +19,13 @@ import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AboutFragment : DaggerFragment() {
+class AboutFragment : DaggerFragment(R.layout.fragment_about) {
 
     @Inject
     lateinit var aboutModelFactory: AboutViewModel.Factory
@@ -46,18 +43,9 @@ class AboutFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_about,
-            container,
-            false
-        )
-        return binding.root
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding = FragmentAboutBinding.bind(view)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -2,12 +2,9 @@ package io.github.droidkaigi.confsched2020.announcement.ui
 
 import android.graphics.Rect
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -16,7 +13,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.announcement.R
 import io.github.droidkaigi.confsched2020.announcement.databinding.FragmentAnnouncementBinding
@@ -26,12 +22,13 @@ import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AnnouncementFragment : DaggerFragment() {
+class AnnouncementFragment : DaggerFragment(R.layout.fragment_announcement) {
 
     @Inject
     lateinit var announcementModelFactory: AnnouncementViewModel.Factory
@@ -52,21 +49,10 @@ class AnnouncementFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_announcement,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentAnnouncementBinding.bind(view)
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.announcementRecycler.run {

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -27,7 +27,7 @@ import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class ContributorsFragment : Fragment() {
+class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
 
     private var binding: FragmentContributorsBinding by autoCleared()
 
@@ -38,22 +38,10 @@ class ContributorsFragment : Fragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_contributors,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentContributorsBinding.bind(view)
 
         val appComponent = (requireContext().applicationContext as App).appComponent
         val component = DaggerContributorComponent.factory()

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -1,36 +1,25 @@
 package io.github.droidkaigi.confsched2020.floormap.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.floormap.R
 import io.github.droidkaigi.confsched2020.floormap.databinding.FragmentFloormapBinding
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.autoCleared
 
 // TODO: Apply the floor map UI
-class FloorMapFragment : DaggerFragment() {
+class FloorMapFragment : DaggerFragment(R.layout.fragment_floormap) {
 
     private var binding: FragmentFloormapBinding by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_floormap,
-            container,
-            false
-        )
-        return binding.root
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding = FragmentFloormapBinding.bind(view)
     }
 
     @Module

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetDaySessionsFragment.kt
@@ -1,12 +1,10 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -15,7 +13,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -28,11 +25,12 @@ import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewMod
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.session.ui.widget.SessionsItemDecoration
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class BottomSheetDaySessionsFragment : DaggerFragment() {
+class BottomSheetDaySessionsFragment : DaggerFragment(R.layout.fragment_bottom_sheet_sessions) {
 
     private var binding: FragmentBottomSheetSessionsBinding by autoCleared()
 
@@ -61,22 +59,11 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
         BottomSheetDaySessionsFragmentArgs.fromBundle(arguments ?: Bundle())
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_bottom_sheet_sessions,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentBottomSheetSessionsBinding.bind(view)
+
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.sessionRecycler.adapter = groupAdapter
         binding.sessionRecycler.addItemDecoration(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -1,12 +1,10 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -15,7 +13,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -26,11 +23,13 @@ import io.github.droidkaigi.confsched2020.session.databinding.FragmentBottomShee
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewModel
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
+class BottomSheetFavoriteSessionsFragment :
+    DaggerFragment(R.layout.fragment_bottom_sheet_favorite_session) {
 
     private var binding: FragmentBottomSheetFavoriteSessionBinding by autoCleared()
 
@@ -50,22 +49,13 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
     @Inject
     lateinit var sessionItemFactory: SessionItem.Factory
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_bottom_sheet_favorite_session,
-            container,
-            false
-        )
-        return binding.apply { isEmptySessions = false }.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentBottomSheetFavoriteSessionBinding.bind(view).apply {
+            isEmptySessions = false
+        }
+
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.sessionRecycler.adapter = groupAdapter
         binding.startFilter.setOnClickListener {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -1,14 +1,11 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -18,11 +15,9 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.soywiz.klock.DateTime
-import com.soywiz.klock.hours
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.model.SessionPage
@@ -33,12 +28,13 @@ import io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragmentDirecti
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class MainSessionsFragment : DaggerFragment() {
+class MainSessionsFragment : DaggerFragment(R.layout.fragment_main_sessions) {
 
     private var binding: FragmentMainSessionsBinding by autoCleared()
 
@@ -58,23 +54,10 @@ class MainSessionsFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_main_sessions,
-            container,
-            false
-        )
-        setHasOptionsMenu(true)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding = FragmentMainSessionsBinding.bind(view)
+        setHasOptionsMenu(true)
         setupSessionPager()
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -2,17 +2,14 @@ package io.github.droidkaigi.confsched2020.session.ui
 
 import android.app.Activity
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -20,7 +17,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -36,12 +32,13 @@ import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SearchSessionsVie
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.session.ui.widget.SearchItemDecoration
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
-import java.util.Locale
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.autoCleared
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SearchSessionsFragment : DaggerFragment() {
+class SearchSessionsFragment : DaggerFragment(R.layout.fragment_search_sessions) {
 
     private var binding: FragmentSearchSessionsBinding by autoCleared()
 
@@ -74,20 +71,6 @@ class SearchSessionsFragment : DaggerFragment() {
         setHasOptionsMenu(true)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_search_sessions,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         view?.let {
@@ -99,6 +82,9 @@ class SearchSessionsFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentSearchSessionsBinding.bind(view)
+
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.searchSessionRecycler.adapter = groupAdapter
         context?.let {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -6,7 +6,6 @@ import android.text.TextPaint
 import android.text.TextUtils
 import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
@@ -18,7 +17,6 @@ import androidx.core.text.color
 import androidx.core.text.inSpans
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -34,7 +32,6 @@ import coil.transform.CircleCropTransformation
 import com.google.android.material.chip.Chip
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -51,6 +48,7 @@ import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirect
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionDetailViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
@@ -58,7 +56,7 @@ import javax.inject.Provider
 
 private const val ELLIPSIS_LINE_COUNT = 6
 
-class SessionDetailFragment : DaggerFragment() {
+class SessionDetailFragment : DaggerFragment(R.layout.fragment_session_detail) {
 
     private var binding: FragmentSessionDetailBinding by autoCleared()
 
@@ -81,22 +79,11 @@ class SessionDetailFragment : DaggerFragment() {
         private const val TRANSITION_NAME_SUFFIX = "detail"
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_session_detail,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentSessionDetailBinding.bind(view)
+
         progressTimeLatch = ProgressTimeLatch { showProgress ->
             binding.progressBar.isVisible = showProgress
         }.apply {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -3,15 +3,12 @@ package io.github.droidkaigi.confsched2020.session.ui
 import android.content.res.Resources
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.children
 import androidx.core.view.updatePadding
-import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -24,7 +21,6 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -39,11 +35,12 @@ import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionTabViewMod
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionsViewModel
 import io.github.droidkaigi.confsched2020.ui.widget.FilterChip
 import io.github.droidkaigi.confsched2020.ui.widget.onCheckedChanged
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionsFragment : DaggerFragment() {
+class SessionsFragment : DaggerFragment(R.layout.fragment_sessions) {
 
     private var binding: FragmentSessionsBinding by autoCleared()
     private lateinit var overrideBackPressedCallback: OnBackPressedCallback
@@ -86,23 +83,12 @@ class SessionsFragment : DaggerFragment() {
             }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_sessions,
-            container,
-            false
-        )
-        setHasOptionsMenu(true)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentSessionsBinding.bind(view)
+        setHasOptionsMenu(true)
+
         initBottomSheetShapeAppearance()
         val initialPeekHeight = sessionSheetBehavior.peekHeight
         val gestureNavigationBottomSpace =

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -1,12 +1,9 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
@@ -17,7 +14,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.session.R
@@ -25,11 +21,12 @@ import io.github.droidkaigi.confsched2020.session.databinding.FragmentSpeakerBin
 import io.github.droidkaigi.confsched2020.session.ui.item.SpeakerDetailItem
 import io.github.droidkaigi.confsched2020.session.ui.item.SpeakerSessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SpeakerViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 
-class SpeakerFragment : DaggerFragment() {
+class SpeakerFragment : DaggerFragment(R.layout.fragment_speaker) {
 
     private var binding: FragmentSpeakerBinding by autoCleared()
 
@@ -52,23 +49,12 @@ class SpeakerFragment : DaggerFragment() {
             }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_speaker,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         postponeEnterTransition()
+
+        binding = FragmentSpeakerBinding.bind(view)
+
         progressTimeLatch = ProgressTimeLatch { showProgress ->
             binding.progressBar.isVisible = showProgress
         }.apply {

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -1,17 +1,13 @@
 package io.github.droidkaigi.confsched2020.session_survey.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.fragment.navArgs
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -19,12 +15,13 @@ import io.github.droidkaigi.confsched2020.session_survey.R
 import io.github.droidkaigi.confsched2020.session_survey.databinding.FragmentSessionSurveyBinding
 import io.github.droidkaigi.confsched2020.session_survey.ui.viewmodel.SessionSurveyViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionSurveyFragment : DaggerFragment() {
+class SessionSurveyFragment : DaggerFragment(R.layout.fragment_session_survey) {
 
     @Inject
     lateinit var sessionSurveyModelFactory: SessionSurveyViewModel.Factory
@@ -43,18 +40,9 @@ class SessionSurveyFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_session_survey,
-            container,
-            false
-        )
-        return binding.root
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding = FragmentSessionSurveyBinding.bind(view)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -1,11 +1,8 @@
 package io.github.droidkaigi.confsched2020.sponsor.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
-import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -16,7 +13,6 @@ import com.xwray.groupie.Section
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -30,12 +26,13 @@ import io.github.droidkaigi.confsched2020.sponsor.ui.item.LargeSponsorItem
 import io.github.droidkaigi.confsched2020.sponsor.ui.item.SponsorItem
 import io.github.droidkaigi.confsched2020.sponsor.ui.viewmodel.SponsorsViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
+import io.github.droidkaigi.confsched2020.util.DaggerFragment
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SponsorsFragment : DaggerFragment() {
+class SponsorsFragment : DaggerFragment(R.layout.fragment_sponsors) {
 
     private var binding: FragmentSponsorsBinding by autoCleared()
 
@@ -56,22 +53,10 @@ class SponsorsFragment : DaggerFragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_sponsors,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentSponsorsBinding.bind(view)
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         groupAdapter.spanCount = 2

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -30,7 +30,7 @@ import io.github.droidkaigi.confsched2020.util.autoCleared
 import javax.inject.Inject
 import javax.inject.Provider
 
-class StaffsFragment : Fragment() {
+class StaffsFragment : Fragment(R.layout.fragment_staffs) {
 
     private var binding: FragmentStaffsBinding by autoCleared()
 
@@ -43,22 +43,10 @@ class StaffsFragment : Fragment() {
 
     private var progressTimeLatch: ProgressTimeLatch by autoCleared()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.fragment_staffs,
-            container,
-            false
-        )
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        binding = FragmentStaffsBinding.bind(view)
 
         val appComponent = (requireContext().applicationContext as App).appComponent
         val component = DaggerStaffComponent.factory()


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Specify layout resource on fragment constructor
  - Now, the new constructor of Fragment is supplied to specify the layout. We can use it to inflate automatically on onCreateView.
- Original DaggerFragment doesn't support AndroidX yet. So, I re-implement it to apply Fragment of AndroidX.
## Links
- https://developer.android.com/reference/kotlin/androidx/fragment/app/Fragment?hl=en#%3Cinit%3E(kotlin.Int)

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
