### PR TITLE
Change app name for debug

### DIFF
--- a/android-base/src/debug/res/values/strings.xml
+++ b/android-base/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">DK2020 Debug</string>
+</resources>


### PR DESCRIPTION
## Issue
- close #381 

## Overview (Required)
- changed app name for debug 
   - `DroidKaigi 2020` -> `DK2020 Debug`

※ I tried [easylauncher-gradle-plugin](https://github.com/akaita/easylauncher-gradle-plugin), but it doesn't yet support vector drawables, so I could not use it...

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12453846/72676989-ba3c0a80-3ada-11ea-8fd1-67990711b8dd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12453846/72676991-bc05ce00-3ada-11ea-81fa-60e4e61cae7a.png" width="300" />
