### PR TITLE
Fix gradle obsolete API warnings

### DIFF
--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -10,7 +10,9 @@ apply plugin: 'kotlinx-serialization'
 apply from: rootProject.file('gradle/android.gradle')
 android.libraryVariants.all {
     // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-    it.generateBuildConfig.enabled = true
+    it.generateBuildConfigProvider.configure {
+        enabled = true
+    }
 }
 
 kotlin {

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -10,7 +10,9 @@ android {
     }
     libraryVariants.all {
         // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-        it.generateBuildConfig.enabled = false
+        it.generateBuildConfigProvider.configure {
+            enabled = false
+        }
     }
     buildTypes {
         release {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fix the following warning on build
```
build.gradle: API 'variant.getGenerateBuildConfig()' is obsolete and has been replaced with 'variant.getGenerateBuildConfigProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
```
## Links
- https://d.android.com/r/tools/task-configuration-avoidance
