### PR TITLE
Fix do not transition to SpeakerFragment when loading image is failure

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
@@ -52,10 +52,15 @@ class SpeakerDetailItem @AssistedInject constructor(
             placeholder(placeHolder)
             transformations(CircleCropTransformation())
             lifecycle(lifecycleOwnerLiveData.value)
-            target {
-                viewBinding.speakerImage.setImageDrawable(it)
-                onImageLoadedCallback()
-            }
+            target(
+                onSuccess = {
+                    viewBinding.speakerImage.setImageDrawable(it)
+                    onImageLoadedCallback()
+                },
+                onError = {
+                    onImageLoadedCallback()
+                }
+            )
         }
     }
 


### PR DESCRIPTION
## Issue
- related to #168

## Overview (Required)
- At https://github.com/DroidKaigi/conference-app-2020/pull/403, I call startPostponedEnterTransition when loading image is succeed.
- But I should call this method when loading image is failure. Otherwise we can not move to SpeakerFragment when (for example) network is off.
- Sorry I didn't notice 🙏 

## Links
- None

## Screenshot
- None
