### PR TITLE
Use language change livedata for language change seamless load

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -69,6 +69,7 @@ class AnnouncementFragment : DaggerFragment(R.layout.fragment_announcement) {
         }.apply {
             loading = true
         }
+        announcementViewModel.loadLanguageSetting()
         announcementViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             progressTimeLatch.loading = uiModel.isLoading
             binding.emptyMessage.isVisible = uiModel.isEmpty
@@ -79,7 +80,6 @@ class AnnouncementFragment : DaggerFragment(R.layout.fragment_announcement) {
                 systemViewModel.onError(it)
             }
         }
-        announcementViewModel.load()
     }
 
     private class AnnouncementItemDecoration(val offset: Float) : RecyclerView.ItemDecoration() {

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -69,7 +69,6 @@ class AnnouncementFragment : DaggerFragment(R.layout.fragment_announcement) {
         }.apply {
             loading = true
         }
-
         announcementViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             progressTimeLatch.loading = uiModel.isLoading
             binding.emptyMessage.isVisible = uiModel.isEmpty
@@ -80,6 +79,7 @@ class AnnouncementFragment : DaggerFragment(R.layout.fragment_announcement) {
                 systemViewModel.onError(it)
             }
         }
+        announcementViewModel.load()
     }
 
     private class AnnouncementItemDecoration(val offset: Float) : RecyclerView.ItemDecoration() {

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/viewmodel/AnnouncementViewModel.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/viewmodel/AnnouncementViewModel.kt
@@ -1,17 +1,19 @@
 package io.github.droidkaigi.confsched2020.announcement.ui.viewmodel
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
-import androidx.lifecycle.liveData
+import androidx.lifecycle.viewModelScope
 import com.squareup.inject.assisted.AssistedInject
-import io.github.droidkaigi.confsched2020.model.repository.AnnouncementRepository
 import io.github.droidkaigi.confsched2020.ext.combine
 import io.github.droidkaigi.confsched2020.ext.toAppError
 import io.github.droidkaigi.confsched2020.ext.toLoadingState
 import io.github.droidkaigi.confsched2020.model.Announcement
 import io.github.droidkaigi.confsched2020.model.AppError
 import io.github.droidkaigi.confsched2020.model.LoadState
+import io.github.droidkaigi.confsched2020.model.repository.AnnouncementRepository
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import timber.log.debug
 
@@ -30,19 +32,10 @@ class AnnouncementViewModel @AssistedInject constructor(
         }
     }
 
-    private val announcementLoadStateLiveData: LiveData<LoadState<List<Announcement>>> = liveData {
-        emitSource(
-            announcementRepository.announcements()
-                .toLoadingState()
-                .asLiveData()
-        )
-        try {
-            announcementRepository.refresh()
-        } catch (e: Exception) {
-            // We can show announcements with cache
-            Timber.debug(e) { "Fail announcementRepository.refresh()" }
-        }
-    }
+    private val mutableAnnouncementLoadStateLiveData: MutableLiveData<LoadState<List<Announcement>>> =
+        MutableLiveData()
+    private val announcementLoadStateLiveData: LiveData<LoadState<List<Announcement>>>
+        get() = mutableAnnouncementLoadStateLiveData
 
     val uiModel = combine(
         initialValue = UiModel.EMPTY,
@@ -55,6 +48,22 @@ class AnnouncementViewModel @AssistedInject constructor(
             announcements = announcements,
             isEmpty = !loadState.isLoading && announcements.isEmpty()
         )
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            try {
+                announcementRepository.refresh()
+            } catch (e: Exception) {
+                // We can show announcements with cache
+                Timber.debug(e) { "Fail announcementRepository.refresh()" }
+            }
+            announcementRepository.announcements()
+                .toLoadingState()
+                .collect {
+                    mutableAnnouncementLoadStateLiveData.value = it
+                }
+        }
     }
 
     @AssistedInject.Factory


### PR DESCRIPTION
## Issue
- close #124 

## Overview (Required)
- ~Create `fun load()` in AnnoucementViewmodel.~
- ~Declare mutableLivedata for load function.~
- ~In `onViewCreated`, call `viewModel.load()` .~
- Create mutableLivedata that manage defaultLang.
- When `AnnoucementFragment#OnViewCreated()` called, update defaultLanguage.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7840108/72678298-e14d0900-3ae7-11ea-85d0-2874bfe308b0.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/7840108/72678294-da25fb00-3ae7-11ea-8621-8c3a27f24314.gif" width="300" />


