### PR TITLE
Implemented time summary text with binding adapter in session detail and speaker detail

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -134,7 +134,6 @@ class SessionDetailFragment : DaggerFragment(R.layout.fragment_session_detail) {
         setupSessionDescription(session.desc)
         binding.speechSession = (session as? SpeechSession)
         binding.lang = defaultLang()
-        binding.time.text = session.timeSummary(defaultLang(), defaultTimeZoneOffset())
         if (session is SpeechSession) {
             val langLabel = session.lang.text.getByLang(defaultLang())
             val categoryLabel = session.category.name.getByLang(defaultLang())

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerSessionItem.kt
@@ -29,8 +29,6 @@ class SpeakerSessionItem @AssistedInject constructor(
         viewBinding.speechSession = speechSession
         viewBinding.lang = defaultLang()
 
-        viewBinding.time.text = speechSession.timeSummary(defaultLang(), defaultTimeZoneOffset())
-
         viewBinding.session.setOnClickListener {
             viewBinding.root.findNavController().navigate(
                 SpeakerFragmentDirections.actionSpeakerToSessionDetail(

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -7,6 +7,8 @@
 
     <data>
 
+        <import type="io.github.droidkaigi.confsched2020.model.TimeZoneOffsetKt" />
+
         <variable
             name="session"
             type="io.github.droidkaigi.confsched2020.model.Session"
@@ -95,6 +97,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
+                    android:text="@{session.timeSummary(lang, TimeZoneOffsetKt.defaultTimeZoneOffset())}"
                     android:textAppearance="?textAppearanceCaption"
                     android:textColor="?android:attr/textColorPrimary"
                     app:layout_constraintBottom_toBottomOf="@id/time_icon"
@@ -102,7 +105,6 @@
                     app:layout_constraintTop_toTopOf="@id/time_icon"
                     tools:text="2月20日 11:00-11:20"
                     />
-                <!--  FIXME: use android:text="@{session.timeSummary(lang, timeOffset)}"-->
 
                 <TextView
                     android:id="@+id/duration_room"

--- a/feature/session/src/main/res/layout/item_speaker_session.xml
+++ b/feature/session/src/main/res/layout/item_speaker_session.xml
@@ -7,6 +7,8 @@
 
     <data>
 
+        <import type="io.github.droidkaigi.confsched2020.model.TimeZoneOffsetKt" />
+
         <variable
             name="speechSession"
             type="io.github.droidkaigi.confsched2020.model.SpeechSession"
@@ -79,13 +81,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
+                android:text="@{speechSession.timeSummary(lang, TimeZoneOffsetKt.defaultTimeZoneOffset())}"
                 android:textAppearance="@style/TextAppearance.DroidKaigi.Caption"
                 app:layout_constraintBottom_toBottomOf="@id/time_icon"
                 app:layout_constraintStart_toEndOf="@id/time_icon"
                 app:layout_constraintTop_toTopOf="@id/time_icon"
                 tools:text="2月20日 11:00-11:20"
                 />
-            <!--  FIXME: use android:text="@{session.timeSummary(lang, timeOffset)}"-->
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
@@ -39,6 +39,9 @@ sealed class Session(
         append(endTimeTZ.format("HH:mm"))
     }
 
+    // See https://github.com/DroidKaigi/conference-app-2020/issues/419
+    fun timeSummary(lang: Lang, timezoneOffset: Double) = timeSummary(lang, TimezoneOffset(timezoneOffset))
+
     fun summary(lang: Lang, timezoneOffset: TimezoneOffset) = buildString {
         append(timeSummary(lang, timezoneOffset))
         append(" / ")


### PR DESCRIPTION
## Issue
- close #419

## Overview (Required)
- According to Fixme comment, time summary text was rewritten using binding adapter.
- But `timeSummary(Lang, TimezoneOffset)` method could not be bind to xml due to the Kotlin inline class.
- So added `timeSummary(Lang, Double)` method to avoid compilation errors.
- I want to know the correct way to resole this if you know it.

## Links
- https://github.com/DroidKaigi/conference-app-2020/issues/419#issuecomment-575976884