### PR TITLE
Scroll to current time session when tapping tab

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -104,7 +104,7 @@ class MainSessionsFragment : DaggerFragment() {
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabReselected(tab: TabLayout.Tab?) {
                     tab?.let {
-                        //                        sessionPagesActionCreator.reselectTab(SessionPage.pages[it.position])
+                        sessionsViewModel.onTabReselected()
                     }
                 }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
@@ -97,7 +97,8 @@ class SessionsViewModel @Inject constructor(
         val sessions = sessionContents.sessions
         val filteredSessions = sessions.filtered(filters)
         val dayToSessionMap = filteredSessions.dayToSessionMap
-        val shouldScrollSessionPosition = if(shouldScroll) filteredSessions.toPageToScrollPositionMap() else emptyMap()
+        val shouldScrollSessionPosition =
+            if (shouldScroll) filteredSessions.toPageToScrollPositionMap() else emptyMap()
 
         UiModel(
             isLoading = isLoading,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
@@ -97,7 +97,7 @@ class SessionsViewModel @Inject constructor(
         val sessions = sessionContents.sessions
         val filteredSessions = sessions.filtered(filters)
         val dayToSessionMap = filteredSessions.dayToSessionMap
-        val shouldScrollSessionPosition = filteredSessions.toPageToScrollPositionMap()
+        val shouldScrollSessionPosition = if(shouldScroll) filteredSessions.toPageToScrollPositionMap() else emptyMap()
 
         UiModel(
             isLoading = isLoading,
@@ -191,5 +191,9 @@ class SessionsViewModel @Inject constructor(
 
     fun onScrolled() {
         shouldScrollCurrentSessionLiveData.value = false
+    }
+
+    fun onTabReselected() {
+        shouldScrollCurrentSessionLiveData.value = true
     }
 }


### PR DESCRIPTION
## Issue

- close #152 

## Overview (Required)

- Scroll to the current session, when tapping tab.

## Links

## Screenshot
Before | After(After tapping a tab)
:--: | :--:
<img src="https://user-images.githubusercontent.com/8476394/72681880-30586580-3b0b-11ea-99b4-fce45ea03733.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8476394/72681921-92b16600-3b0b-11ea-9945-e44508fe6da0.png" width="300" />
