### PR TITLE
Fix "Crash when click on favorite button of first cell in sessions list"

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
@@ -45,7 +45,7 @@ class SessionsItemDecoration(
             val sessionItem = adapter.getItem(position) as SessionItem
             val startTimeText = calcTimeText(position, view)
 
-            if (index > 0) {
+            if (position > 0) {
                 val lastSessionItem = adapter.getItem(position - 1) as SessionItem
                 if (sessionItem.startSessionTime() == lastSessionItem.startSessionTime()) return@forEachIndexed
             }


### PR DESCRIPTION
## Issue
- close #289 

## Overview (Required)
- Fix expression to prevent `IndexOutOfBoundsException`
  - Since  `index` and `position` are **usually** the same value, there is no problem if `index > 0` is true.(instead of `position > 0` is true)
  - But there is an unexpected case that `index` and `position` have different values.
    - this unexpected problem was fixed by any PR. (I can't find this PR)
  - So I submit this PR, this PR may not be needed.