### PR TITLE
Use target sdk version 29 and compile sdk version 29

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched2020
 
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.BuildCompat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreSettings
@@ -43,7 +43,7 @@ open class App : DaggerApplication(), AppComponentHolder {
     }
 
     private fun setupNightMode() {
-        val nightMode = if (BuildCompat.isAtLeastQ()) {
+        val nightMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
         } else {
             AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -1,8 +1,8 @@
 package dependencies
 
 private object Versions {
-    val androidTargetSdkVersion = 28
-    val androidCompileSdkVersion = 28
+    val androidTargetSdkVersion = 29
+    val androidCompileSdkVersion = 29
     val androidMinSdkVersion = 21
 
     private val versionMajor = 1

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -1,16 +1,16 @@
 package dependencies
 
 private object Versions {
-    val androidTargetSdkVersion = 29
-    val androidCompileSdkVersion = 29
-    val androidMinSdkVersion = 21
+    const val androidTargetSdkVersion = 29
+    const val androidCompileSdkVersion = 29
+    const val androidMinSdkVersion = 21
 
-    private val versionMajor = 1
-    private val versionMinor = 0
-    private val versionPatch = 5
-    private val versionOffset = 0
-    val androidVersionCode =
+    private const val versionMajor = 1
+    private const val versionMinor = 0
+    private const val versionPatch = 5
+    private const val versionOffset = 0
+    const val androidVersionCode =
         (versionMajor * 10000 + versionMinor * 100 + versionPatch) * 100 + versionOffset
 
-    val androidVersionName = "$versionMajor.$versionMinor.$versionPatch"
+    const val androidVersionName = "$versionMajor.$versionMinor.$versionPatch"
 }

--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -1,16 +1,16 @@
 package dependencies
 
 private object Versions {
-    const val androidTargetSdkVersion = 29
-    const val androidCompileSdkVersion = 29
-    const val androidMinSdkVersion = 21
+    val androidTargetSdkVersion = 29
+    val androidCompileSdkVersion = 29
+    val androidMinSdkVersion = 21
 
-    private const val versionMajor = 1
-    private const val versionMinor = 0
-    private const val versionPatch = 5
-    private const val versionOffset = 0
-    const val androidVersionCode =
+    private val versionMajor = 1
+    private val versionMinor = 0
+    private val versionPatch = 5
+    private val versionOffset = 0
+    val androidVersionCode =
         (versionMajor * 10000 + versionMinor * 100 + versionPatch) * 100 + versionOffset
 
-    const val androidVersionName = "$versionMajor.$versionMinor.$versionPatch"
+    val androidVersionName = "$versionMajor.$versionMinor.$versionPatch"
 }


### PR DESCRIPTION
## Issue
- close #454 

## Overview (Required)
- change targetSdkVersion and compileSdkVersion to 29
- Because BuildCompat.isAtLeastQ became Deprecated, use Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q.
- ~change val to const val as in Packages.kt~

I tried to fix the two below, but I will revert if there is a problem !! 🙇