### PR TITLE
Generates a library cache for CI

### DIFF
--- a/.github/workflows/generate_caches.yml
+++ b/.github/workflows/generate_caches.yml
@@ -1,10 +1,8 @@
 name: Genarate caches
 
-on: pull_request
-
-#  push:
-#    branches:
-#      - master # specify default branch and main base branch
+push:
+  branches:
+    - master # specify default branch and main base branches of pull request
 
 jobs:
   ganerate-m2-cache:

--- a/.github/workflows/generate_caches.yml
+++ b/.github/workflows/generate_caches.yml
@@ -1,0 +1,46 @@
+name: Genarate caches
+
+on: pull_request
+
+#  push:
+#    branches:
+#      - master # specify default branch and main base branch
+
+jobs:
+  ganerate-m2-cache:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - uses: actions/cache@v1
+        id: cache
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-${{ hashFiles('**/*.gradle.kts') }}-
+            ${{ runner.os }}-m2-
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: ./gradlew androidDependenciesExtra dependencies
+        shell: bash
+
+  ganerate-bundle-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "::set-output name=version::$(cat .ruby-version)"
+        id: ruby
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby.outputs.version }}
+      - uses: actions/cache@v1
+        id: cache
+        with:
+          path: .ci/vendor/bundle
+          key: ${{ runner.os }}-bundle-${{ hashFiles('.ci/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bundle-
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: bundle check || bundle install --path=vendor/bundle --jobs=4 --clean --gemfile=.ci/Gemfile

--- a/.github/workflows/generate_caches.yml
+++ b/.github/workflows/generate_caches.yml
@@ -1,8 +1,9 @@
 name: Genarate caches
 
-push:
-  branches:
-    - master # specify default branch and main base branches of pull request
+on:
+  push:
+    branches:
+      - master # specify default branch and main base branches of pull request
 
 jobs:
   ganerate-m2-cache:


### PR DESCRIPTION
## Issue
- close #338 

## Overview (Required)
- Generates a library cache for CI when the pull request is merged into master.
  - This allows the cache to be used immediately when creating a new pull request.

## Links

## Screenshot
