### PR TITLE
#104 Issue resolved

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.SpannableStringBuilder
@@ -94,6 +95,7 @@ class SessionDetailFragment : DaggerFragment() {
             container,
             false
         )
+        activity!!.window.navigationBarColor = Color.parseColor("#88FFFFFF")
         return binding.root
     }
 
@@ -325,6 +327,11 @@ class SessionDetailFragment : DaggerFragment() {
         setCompoundDrawables(
             drawable, null, null, null
         )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        activity!!.window.navigationBarColor = Color.parseColor("#00FFFFFF")
     }
 }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
-import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.SpannableStringBuilder
@@ -45,12 +44,10 @@ import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.Speaker
 import io.github.droidkaigi.confsched2020.model.SpeechSession
 import io.github.droidkaigi.confsched2020.model.defaultLang
-import io.github.droidkaigi.confsched2020.model.defaultTimeZoneOffset
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.FragmentSessionDetailBinding
 import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToChrome
 import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSpeaker
-import io.github.droidkaigi.confsched2020.session.ui.SessionDetailFragmentDirections.Companion.actionSessionToSurvey
 import io.github.droidkaigi.confsched2020.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2020.session.ui.viewmodel.SessionDetailViewModel
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
@@ -95,7 +92,7 @@ class SessionDetailFragment : DaggerFragment() {
             container,
             false
         )
-        activity!!.window.navigationBarColor = Color.parseColor("#88FFFFFF")
+        activity?.window?.decorView?.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
         return binding.root
     }
 
@@ -327,11 +324,6 @@ class SessionDetailFragment : DaggerFragment() {
         setCompoundDrawables(
             drawable, null, null, null
         )
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        activity!!.window.navigationBarColor = Color.parseColor("#00FFFFFF")
     }
 }
 


### PR DESCRIPTION
## Issue
- close #104 

## Overview (Required)
- The colors of the icons on the bottom sheet and the navigation bar are similar, making it difficult to see.

## Notes
- I really wanted to get a swipe verdict for `ButtomAppBar` . Upon examination, I found no Listener that could be used in `BottomAppBar` .
- Looking for other alternatives, `AppbarLayout` seemed to have an `AppBarLayout.OnOffsetChangedListener`so I could do it.
But `AppbarLayout` didn't seem to be able to insert a `FloatingActionButton` .
Therefore, I decided not to make a swipe decision and set translucent white.

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
![image](https://user-images.githubusercontent.com/19369026/72698423-7fdc7700-3b87-11ea-97d0-5bd3841cb5e5.png) | ![image](https://user-images.githubusercontent.com/19369026/72698368-4572da00-3b87-11ea-80ce-1acbe835514a.png)
