### PR TITLE
fix a placeholder image is not shown when offline at the speaker screen.

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
@@ -1,5 +1,6 @@
 package io.github.droidkaigi.confsched2020.session.ui.item
 
+import android.content.Context
 import android.text.method.LinkMovementMethod
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
@@ -15,6 +16,7 @@ import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Speaker
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSpeakerDetailBinding
+import io.github.droidkaigi.confsched2020.util.lazyWithParam
 import javax.inject.Named
 
 class SpeakerDetailItem @AssistedInject constructor(
@@ -25,6 +27,18 @@ class SpeakerDetailItem @AssistedInject constructor(
     private val lifecycleOwnerLiveData: LiveData<LifecycleOwner>
 ) : BindableItem<ItemSpeakerDetailBinding>(speaker.id.hashCode().toLong()),
     EqualableContentsProvider {
+
+    private val placeholder by lazyWithParam<Context, VectorDrawableCompat?> { context ->
+        VectorDrawableCompat.create(
+            context.resources,
+            R.drawable.ic_person_outline_black_32dp,
+            null
+        )?.apply {
+            setTint(
+                ContextCompat.getColor(context, R.color.speaker_icon)
+            )
+        }
+    }
 
     override fun getLayout(): Int = R.layout.item_speaker_detail
 
@@ -37,19 +51,10 @@ class SpeakerDetailItem @AssistedInject constructor(
         speaker.imageUrl ?: onImageLoadedCallback()
 
         val context = viewBinding.root.context
-        val placeHolder = VectorDrawableCompat.create(
-            context.resources,
-            R.drawable.ic_person_outline_black_32dp,
-            null
-        )?.apply {
-            setTint(
-                ContextCompat.getColor(context, R.color.speaker_icon)
-            )
-        }
 
         Coil.load(context, speaker.imageUrl) {
             crossfade(true)
-            placeholder(placeHolder)
+            placeholder(placeholder.get(context))
             transformations(CircleCropTransformation())
             lifecycle(lifecycleOwnerLiveData.value)
             target(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SpeakerDetailItem.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched2020.session.ui.item
 
-import android.content.Context
 import android.text.method.LinkMovementMethod
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
@@ -11,7 +11,6 @@ import coil.transform.CircleCropTransformation
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.databinding.BindableItem
-import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Speaker
 import io.github.droidkaigi.confsched2020.session.R
@@ -23,20 +22,9 @@ class SpeakerDetailItem @AssistedInject constructor(
     @Assisted @Named("transitionNameSuffix")
     val transitionNameSuffix: String,
     @Assisted val onImageLoadedCallback: () -> Unit,
-    private val context: Context,
     private val lifecycleOwnerLiveData: LiveData<LifecycleOwner>
 ) : BindableItem<ItemSpeakerDetailBinding>(speaker.id.hashCode().toLong()),
     EqualableContentsProvider {
-
-    private val placeHolder = VectorDrawableCompat.create(
-        context.resources,
-        R.drawable.ic_person_outline_black_32dp,
-        null
-    )?.apply {
-        setTint(
-            context.getThemeColor(R.attr.colorOnBackground)
-        )
-    }
 
     override fun getLayout(): Int = R.layout.item_speaker_detail
 
@@ -48,12 +36,26 @@ class SpeakerDetailItem @AssistedInject constructor(
 
         speaker.imageUrl ?: onImageLoadedCallback()
 
+        val context = viewBinding.root.context
+        val placeHolder = VectorDrawableCompat.create(
+            context.resources,
+            R.drawable.ic_person_outline_black_32dp,
+            null
+        )?.apply {
+            setTint(
+                ContextCompat.getColor(context, R.color.speaker_icon)
+            )
+        }
+
         Coil.load(context, speaker.imageUrl) {
             crossfade(true)
             placeholder(placeHolder)
             transformations(CircleCropTransformation())
             lifecycle(lifecycleOwnerLiveData.value)
             target(
+                onStart = {
+                    viewBinding.speakerImage.setImageDrawable(it)
+                },
                 onSuccess = {
                     viewBinding.speakerImage.setImageDrawable(it)
                     onImageLoadedCallback()


### PR DESCRIPTION
## Issue
- close #313

## Overview (Required)
- The speaker screen already had a placeholder icon. but it not had set that placeholder ImageView when starting the image loading by Coil.

## Screenshot
### Offline(Speaker image is not loaded)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1004668/72746397-607c3300-3bf5-11ea-88d5-93213e6dcf9a.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1004668/72745537-4fcabd80-3bf3-11ea-8275-20fa934bdd3f.gif" width="300" />
### Online(Speaker image is loaded)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1004668/72746383-5a865200-3bf5-11ea-8ccb-ab295279060d.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1004668/72745739-c9fb4200-3bf3-11ea-9796-3530c25dbc0d.gif" width="300" />