### PR TITLE
Disable fade in effect in SessionDetailFragment when click session favorite button

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -14,6 +14,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.SimpleItemAnimator
 import com.xwray.groupie.Group
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
@@ -113,6 +114,10 @@ class SessionDetailFragment : DaggerFragment() {
                     it
                 )
             )
+        }
+        val itemAnimator = binding.sessionDetailRecycler.itemAnimator
+        if (itemAnimator is SimpleItemAnimator) {
+            itemAnimator.supportsChangeAnimations = false
         }
 
         progressTimeLatch = ProgressTimeLatch { showProgress ->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -15,6 +15,7 @@ import androidx.core.view.doOnPreDraw
 import androidx.transition.TransitionManager
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.session.R
@@ -23,7 +24,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailD
 class SessionDetailDescriptionItem @AssistedInject constructor(
     @Assisted private val session: Session
 ) :
-    BindableItem<ItemSessionDetailDescriptionBinding>(1L) {
+    BindableItem<ItemSessionDetailDescriptionBinding>() {
 
     companion object {
         private const val ELLIPSIS_LINE_COUNT = 6
@@ -32,6 +33,8 @@ class SessionDetailDescriptionItem @AssistedInject constructor(
     private var showEllipsis = true
 
     override fun getLayout() = R.layout.item_session_detail_description
+
+    override fun isSameAs(other: Item<*>?): Boolean = other is SessionDetailDescriptionItem
 
     override fun bind(binding: ItemSessionDetailDescriptionBinding, position: Int) {
         val fullDescription = session.desc

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -23,7 +23,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailD
 class SessionDetailDescriptionItem @AssistedInject constructor(
     @Assisted private val session: Session
 ) :
-    BindableItem<ItemSessionDetailDescriptionBinding>() {
+    BindableItem<ItemSessionDetailDescriptionBinding>(1L) {
 
     companion object {
         private const val ELLIPSIS_LINE_COUNT = 6

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
@@ -15,7 +15,7 @@ class SessionDetailMaterialItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val listener: Listener
 ) :
-    BindableItem<ItemSessionDetailMaterialBinding>() {
+    BindableItem<ItemSessionDetailMaterialBinding>(1L) {
 
     interface Listener {
         fun onClickMovie(movieUrl: String)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
@@ -5,6 +5,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SpeechSession
@@ -15,7 +16,7 @@ class SessionDetailMaterialItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val listener: Listener
 ) :
-    BindableItem<ItemSessionDetailMaterialBinding>(1L) {
+    BindableItem<ItemSessionDetailMaterialBinding>() {
 
     interface Listener {
         fun onClickMovie(movieUrl: String)
@@ -28,6 +29,8 @@ class SessionDetailMaterialItem @AssistedInject constructor(
     override fun bind(binding: ItemSessionDetailMaterialBinding, position: Int) {
         setUpMaterialData(binding)
     }
+
+    override fun isSameAs(other: Item<*>?) = other is SessionDetailMaterialItem
 
     private fun setUpMaterialData(binding: ItemSessionDetailMaterialBinding) {
         if (session is SpeechSession) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerItem.kt
@@ -27,7 +27,7 @@ class SessionDetailSpeakerItem @AssistedInject constructor(
     @Assisted private val speaker: Speaker,
     @Assisted val first: Boolean,
     @Assisted private val onClick: (FragmentNavigator.Extras) -> Unit
-) : BindableItem<ItemSessionDetailSpeakerBinding>() {
+) : BindableItem<ItemSessionDetailSpeakerBinding>(speaker.id.hashCode().toLong()) {
     override fun getLayout() = R.layout.item_session_detail_speaker
 
     override fun bind(binding: ItemSessionDetailSpeakerBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
@@ -1,16 +1,19 @@
 package io.github.droidkaigi.confsched2020.session.ui.item
 
 import com.squareup.inject.assisted.AssistedInject
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailSpeakerSubtitleBinding
 
 class SessionDetailSpeakerSubtitleItem @AssistedInject constructor() :
-    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>(1L) {
+    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>() {
     override fun getLayout() = R.layout.item_session_detail_speaker_subtitle
 
     override fun bind(binding: ItemSessionDetailSpeakerSubtitleBinding, position: Int) {
     }
+
+    override fun isSameAs(other: Item<*>?) = other is SessionDetailSpeakerSubtitleItem
 
     @AssistedInject.Factory
     interface Factory {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
@@ -6,7 +6,7 @@ import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailSpeakerSubtitleBinding
 
 class SessionDetailSpeakerSubtitleItem @AssistedInject constructor() :
-    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>() {
+    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>(1L) {
     override fun getLayout() = R.layout.item_session_detail_speaker_subtitle
 
     override fun bind(binding: ItemSessionDetailSpeakerSubtitleBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
@@ -13,7 +13,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailT
  */
 class SessionDetailTargetItem @AssistedInject constructor(
     @Assisted private val session: Session
-) : BindableItem<ItemSessionDetailTargetBinding>() {
+) : BindableItem<ItemSessionDetailTargetBinding>(1L) {
     override fun getLayout() = R.layout.item_session_detail_target
 
     override fun bind(binding: ItemSessionDetailTargetBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2020.session.ui.item
 
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SpeechSession
@@ -13,13 +14,15 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailT
  */
 class SessionDetailTargetItem @AssistedInject constructor(
     @Assisted private val session: Session
-) : BindableItem<ItemSessionDetailTargetBinding>(1L) {
+) : BindableItem<ItemSessionDetailTargetBinding>() {
     override fun getLayout() = R.layout.item_session_detail_target
 
     override fun bind(binding: ItemSessionDetailTargetBinding, position: Int) {
         binding.session = session
         binding.speechSession = (session as? SpeechSession)
     }
+
+    override fun isSameAs(other: Item<*>?) = other is SessionDetailTargetItem
 
     @AssistedInject.Factory
     interface Factory {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
@@ -13,7 +13,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailT
 class SessionDetailTitleItem @AssistedInject constructor(
     @Assisted private val session: Session
 ) :
-    BindableItem<ItemSessionDetailTitleBinding>() {
+    BindableItem<ItemSessionDetailTitleBinding>(1L) {
     override fun getLayout() = R.layout.item_session_detail_title
 
     override fun bind(binding: ItemSessionDetailTitleBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.session.ui.item
 import com.google.android.material.chip.Chip
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SpeechSession
@@ -13,7 +14,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailT
 class SessionDetailTitleItem @AssistedInject constructor(
     @Assisted private val session: Session
 ) :
-    BindableItem<ItemSessionDetailTitleBinding>(1L) {
+    BindableItem<ItemSessionDetailTitleBinding>() {
     override fun getLayout() = R.layout.item_session_detail_title
 
     override fun bind(binding: ItemSessionDetailTitleBinding, position: Int) {
@@ -43,6 +44,8 @@ class SessionDetailTitleItem @AssistedInject constructor(
             }
         }
     }
+
+    override fun isSameAs(other: Item<*>?) = other is SessionDetailTitleItem
 
     @AssistedInject.Factory
     interface Factory {


### PR DESCRIPTION
## Issue

No

## Overview (Required)
- Disable fade in effect in the SessionDetailFragment when click session favorite button.
- It is a degrade of #487


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/16898831/72774141-da8bd680-3c4c-11ea-9e76-e6bd41258f3e.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/16898831/72774164-e8415c00-3c4c-11ea-9aa3-0e4b16164eac.gif" width="300" />


