### PR TITLE
Added editorconfig to disable the ktlint rule for import ordering

### DIFF
--- a/.ci/.editorconfig
+++ b/.ci/.editorconfig
@@ -1,17 +1,1 @@
-root = true
-
-[*]
-indent_style = space
-indent_size = 4
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[*.Dangerfile]
-indent_size = 2
-
-[*.Gemfile]
-indent_size = 2
-
-[*.Rakefile]
-indent_size = 2
+../.editorconfig

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt, kts}]
+# Temporary disabled this rule through .editorconfig due to https://youtrack.jetbrains.com/issue/KT-10974 and https://github.com/pinterest/ktlint/issues/527
+disabled_rules = import-ordering
+
+[*.{Dangerfile,Gemfile,Rakefile}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Issue
- close #503

## Overview (Required)
- Follow the expected behaviour that #503 noted. The reason why we need to do it is also described.
- To check the behaviour, I ran `./gradlew ktlintFormat` and no diffs are generated as expected.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
