### PR TITLE
Make fadingEdge of SponsorFragment expands end to end of the screen

### DIFF
--- a/feature/sponsor/src/main/res/layout/fragment_sponsors.xml
+++ b/feature/sponsor/src/main/res/layout/fragment_sponsors.xml
@@ -16,6 +16,7 @@
             android:id="@+id/sponsor_recycler"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:clipToPadding="false"
             android:orientation="vertical"
             android:paddingStart="8dp"
             android:paddingEnd="8dp"


### PR DESCRIPTION
## Issue
Sorry I forgot to create an issue 🙏 
- close #ISSUE_NUMBER

## Overview (Required)
- `fadingEdge` of SponsorFragment did not expand end to end of the screen.
  - It caused by miss to set `clipToPadding` to false at the RecyclerView of `fragment_sponsor.xml`. 

## Screenshot
(It's hard to see the difference...sorry.)

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/10008419/72804917-02069180-3c95-11ea-86c8-d0d2d7570189.png" width="300" />|<img src="https://user-images.githubusercontent.com/10008419/72804932-0b8ff980-3c95-11ea-8d07-d33a21f424f2.png" width="300" /> 