### PR TITLE
iOS App Hardly see the status bar #499

### DIFF
--- a/ios-base/DroidKaigi 2020/Info.plist
+++ b/ios-base/DroidKaigi 2020/Info.plist
@@ -43,6 +43,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -54,5 +56,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue
- close #499 

## Overview (Required)
- Changed the colors of the font on the status bar to make it easy to see.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/893643/72812848-9f69c180-3ca5-11ea-91c6-4cf5fb32c4c3.png" width="300" /> | <img src="https://user-images.githubusercontent.com/893643/72812847-9f69c180-3ca5-11ea-98c4-c24161b902a2.png" width="300" />
