### PR TITLE
More options for dark theme

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -53,6 +53,7 @@ open class App : DaggerApplication(), AppComponentHolder {
                 .getString(DARK_THEME_KEY, getString(R.string.pref_theme_value_default))) {
                 getString(R.string.pref_theme_value_dark) -> AppCompatDelegate.MODE_NIGHT_YES
                 getString(R.string.pref_theme_value_light) -> AppCompatDelegate.MODE_NIGHT_NO
+                getString(R.string.pref_theme_value_battery) -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
                 else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
             }
         AppCompatDelegate.setDefaultNightMode(nightMode)

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -50,7 +50,7 @@ open class App : DaggerApplication(), AppComponentHolder {
     private fun setupNightMode() {
         val nightMode =
             when (PreferenceManager.getDefaultSharedPreferences(applicationContext)
-                .getString(DARK_THEME_KEY, getString(R.string.pref_theme_value_default))) {
+                .getString(DARK_THEME_KEY, getString(R.string.pref_theme_default))) {
                 getString(R.string.pref_theme_value_dark) -> AppCompatDelegate.MODE_NIGHT_YES
                 getString(R.string.pref_theme_value_light) -> AppCompatDelegate.MODE_NIGHT_NO
                 getString(R.string.pref_theme_value_battery) -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020
 
-import android.os.Build
 import android.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.firebase.FirebaseApp
@@ -16,7 +15,8 @@ import timber.log.LogcatTree
 import timber.log.Timber
 
 open class App : DaggerApplication(), AppComponentHolder {
-    private val SWITCH_DARK_THEME_KEY = "switchDarkTheme"
+
+    private val DARK_THEME_KEY = "darkTheme"
 
     override val appComponent: AppComponent by lazy {
         createAppComponent()
@@ -48,19 +48,13 @@ open class App : DaggerApplication(), AppComponentHolder {
     }
 
     private fun setupNightMode() {
-
-        val nightMode = when {
-            PreferenceManager.getDefaultSharedPreferences(applicationContext)
-                .getBoolean(SWITCH_DARK_THEME_KEY, false) -> {
-                AppCompatDelegate.MODE_NIGHT_YES
+        val nightMode =
+            when (PreferenceManager.getDefaultSharedPreferences(applicationContext)
+                .getString(DARK_THEME_KEY, getString(R.string.pref_theme_value_default))) {
+                getString(R.string.pref_theme_value_dark) -> AppCompatDelegate.MODE_NIGHT_YES
+                getString(R.string.pref_theme_value_light) -> AppCompatDelegate.MODE_NIGHT_NO
+                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
             }
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
-                AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-            }
-            else -> {
-                AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-            }
-        }
         AppCompatDelegate.setDefaultNightMode(nightMode)
     }
 

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -11,12 +11,12 @@ import io.github.droidkaigi.confsched2020.di.AppComponent
 import io.github.droidkaigi.confsched2020.di.AppComponentHolder
 import io.github.droidkaigi.confsched2020.di.createAppComponent
 import io.github.droidkaigi.confsched2020.image.CoilInitializer
+import io.github.droidkaigi.confsched2020.util.Prefs
 import timber.log.LogcatTree
 import timber.log.Timber
 
 open class App : DaggerApplication(), AppComponentHolder {
 
-    private val DARK_THEME_KEY = "darkTheme"
 
     override val appComponent: AppComponent by lazy {
         createAppComponent()
@@ -48,15 +48,7 @@ open class App : DaggerApplication(), AppComponentHolder {
     }
 
     private fun setupNightMode() {
-        val nightMode =
-            when (PreferenceManager.getDefaultSharedPreferences(applicationContext)
-                .getString(DARK_THEME_KEY, getString(R.string.pref_theme_default))) {
-                getString(R.string.pref_theme_value_dark) -> AppCompatDelegate.MODE_NIGHT_YES
-                getString(R.string.pref_theme_value_light) -> AppCompatDelegate.MODE_NIGHT_NO
-                getString(R.string.pref_theme_value_battery) -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
-                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-            }
-        AppCompatDelegate.setDefaultNightMode(nightMode)
+        AppCompatDelegate.setDefaultNightMode(Prefs(this).getNightMode())
     }
 
     private fun setupCoil() {

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020
 
-import android.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FirebaseFirestore
@@ -16,7 +15,6 @@ import timber.log.LogcatTree
 import timber.log.Timber
 
 open class App : DaggerApplication(), AppComponentHolder {
-
 
     override val appComponent: AppComponent by lazy {
         createAppComponent()

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/Prefs.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/Prefs.kt
@@ -1,0 +1,35 @@
+package io.github.droidkaigi.confsched2020.util
+
+import android.content.Context
+import android.preference.PreferenceManager
+import androidx.appcompat.app.AppCompatDelegate
+import io.github.droidkaigi.confsched2020.widget.component.R
+
+class Prefs(
+    private val context: Context
+) {
+
+    fun getNightMode(): Int {
+        return when (PreferenceManager.getDefaultSharedPreferences(context).getString(
+            DARK_THEME_KEY,
+            context.getString(R.string.pref_theme_default)
+        )) {
+            context.getString(R.string.pref_theme_value_dark) -> {
+                AppCompatDelegate.MODE_NIGHT_YES
+            }
+            context.getString(R.string.pref_theme_value_light) -> {
+                AppCompatDelegate.MODE_NIGHT_NO
+            }
+            context.getString(R.string.pref_theme_value_battery) -> {
+                AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+            }
+            else -> {
+                AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            }
+        }
+    }
+
+    companion object {
+        private const val DARK_THEME_KEY = "darkTheme"
+    }
+}

--- a/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -19,4 +19,8 @@
     <string name="notification_message_session_title">%1$s がもうすぐ始まります。</string>
     <string name="notification_message_session_start_time">%1$s ~ %2$s @ %3$s</string>
     <string name="tabular_form_label">タイムテーブル</string>
+    <!-- Preference -->
+    <string name="pref_theme_entry_default">端末設定に従う</string>
+    <string name="pref_theme_entry_light">ライト</string>
+    <string name="pref_theme_entry_dark">ダーク</string>
 </resources>

--- a/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -21,6 +21,7 @@
     <string name="tabular_form_label">タイムテーブル</string>
     <!-- Preference -->
     <string name="pref_theme_entry_default">端末設定に従う</string>
+    <string name="pref_theme_entry_battery">省電力モードの時のみ</string>
     <string name="pref_theme_entry_light">ライト</string>
     <string name="pref_theme_entry_dark">ダーク</string>
 </resources>

--- a/corecomponent/androidcomponent/src/main/res/values-v29/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-v29/strings.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <string name="pref_theme_default" translatable="false">@string/pref_theme_value_default</string>
-    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+    <string-array name="pref_theme_entries">
         <item>@string/pref_theme_entry_light</item>
         <item>@string/pref_theme_entry_dark</item>
         <item>@string/pref_theme_entry_default</item>
     </string-array>
-    <string-array name="pref_theme_entry_values" tools:ignore="InconsistentArrays">
+    <string-array name="pref_theme_entry_values">
         <item>@string/pref_theme_value_light</item>
         <item>@string/pref_theme_value_dark</item>
         <item>@string/pref_theme_value_default</item>

--- a/corecomponent/androidcomponent/src/main/res/values-v29/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-v29/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="pref_theme_default" translatable="false">@string/pref_theme_value_default</string>
+    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+        <item>@string/pref_theme_entry_light</item>
+        <item>@string/pref_theme_entry_dark</item>
+        <item>@string/pref_theme_entry_default</item>
+    </string-array>
+    <string-array name="pref_theme_entry_values" tools:ignore="InconsistentArrays">
+        <item>@string/pref_theme_value_light</item>
+        <item>@string/pref_theme_value_dark</item>
+        <item>@string/pref_theme_value_default</item>
+    </string-array>
+</resources>

--- a/corecomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Session -->
     <string name="session_label">Session</string>
     <!-- Speaker -->
@@ -34,9 +34,25 @@
     <string name="notification_message_session_start_time">%1$s to %2$s @ %3$s</string>
     <!-- Tabular Form -->
     <string name="tabular_form_label">Timetable</string>
-
+    <!-- Preference -->
     <string name="theme_label" translatable="false">Theme</string>
     <string name="dark_theme_label" translatable="false">Dark theme</string>
+    <string name="pref_theme_value_default" translatable="false">default</string>
+    <string name="pref_theme_value_light" translatable="false">light</string>
+    <string name="pref_theme_value_dark" translatable="false">dark</string>
+    <string name="pref_theme_entry_default">System default</string>
+    <string name="pref_theme_entry_light">Light</string>
+    <string name="pref_theme_entry_dark">Dark</string>
+    <!-- override in v29 -->
+    <string name="pref_theme_default" translatable="false">@string/pref_theme_value_light</string>
+    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+        <item>@string/pref_theme_entry_light</item>
+        <item>@string/pref_theme_entry_dark</item>
+    </string-array>
+    <string-array name="pref_theme_entry_values" tools:ignore="InconsistentArrays">
+        <item>@string/pref_theme_value_light</item>
+        <item>@string/pref_theme_value_dark</item>
+    </string-array>
 
     <string name="error_network" translatable="false">A network error has occurred.Please try again.</string>
     <string name="error_server" translatable="false">A server error has occurred.Please try again.</string>

--- a/corecomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/corecomponent/androidcomponent/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Session -->
     <string name="session_label">Session</string>
     <!-- Speaker -->
@@ -38,20 +38,24 @@
     <string name="theme_label" translatable="false">Theme</string>
     <string name="dark_theme_label" translatable="false">Dark theme</string>
     <string name="pref_theme_value_default" translatable="false">default</string>
+    <string name="pref_theme_value_battery" translatable="false">battery</string>
     <string name="pref_theme_value_light" translatable="false">light</string>
     <string name="pref_theme_value_dark" translatable="false">dark</string>
     <string name="pref_theme_entry_default">System default</string>
+    <string name="pref_theme_entry_battery">When battery saver is on</string>
     <string name="pref_theme_entry_light">Light</string>
     <string name="pref_theme_entry_dark">Dark</string>
     <!-- override in v29 -->
-    <string name="pref_theme_default" translatable="false">@string/pref_theme_value_light</string>
-    <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
+    <string name="pref_theme_default" translatable="false">@string/pref_theme_value_battery</string>
+    <string-array name="pref_theme_entries">
         <item>@string/pref_theme_entry_light</item>
         <item>@string/pref_theme_entry_dark</item>
+        <item>@string/pref_theme_entry_battery</item>
     </string-array>
-    <string-array name="pref_theme_entry_values" tools:ignore="InconsistentArrays">
+    <string-array name="pref_theme_entry_values">
         <item>@string/pref_theme_value_light</item>
         <item>@string/pref_theme_value_dark</item>
+        <item>@string/pref_theme_value_battery</item>
     </string-array>
 
     <string name="error_network" translatable="false">A network error has occurred.Please try again.</string>

--- a/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
@@ -61,15 +61,17 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
     // region temporary functions until appropriate structure have built
     private fun String.toNightMode() = when (this) {
+        getString(MainR.string.pref_theme_value_default) -> NightMode.SYSTEM
+        getString(MainR.string.pref_theme_value_battery) -> NightMode.BATTERY
         getString(MainR.string.pref_theme_value_dark) -> NightMode.YES
         getString(MainR.string.pref_theme_value_light) -> NightMode.NO
-        getString(MainR.string.pref_theme_value_default) -> NightMode.SYSTEM
         else -> throw IllegalArgumentException("should not happen")
     }
 
     private val NightMode.platformValue: Int
         get() = when (this) {
             NightMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            NightMode.BATTERY -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
             NightMode.YES -> AppCompatDelegate.MODE_NIGHT_YES
             NightMode.NO -> AppCompatDelegate.MODE_NIGHT_NO
         }

--- a/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
+++ b/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/PreferencesFragment.kt
@@ -1,8 +1,8 @@
 package io.github.droidkaigi.confsched2020.preference.ui
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -55,7 +55,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
         preferenceViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             AppCompatDelegate.setDefaultNightMode(uiModel.nightMode.platformValue)
-            (activity as? AppCompatActivity)?.delegate?.applyDayNight()
         }
     }
 
@@ -70,7 +69,10 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
     private val NightMode.platformValue: Int
         get() = when (this) {
-            NightMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            NightMode.SYSTEM -> {
+                if (Build.VERSION.SDK_INT < 29) AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
+                else AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            }
             NightMode.BATTERY -> AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
             NightMode.YES -> AppCompatDelegate.MODE_NIGHT_YES
             NightMode.NO -> AppCompatDelegate.MODE_NIGHT_NO

--- a/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/viewmodel/PreferenceViewModel.kt
+++ b/feature/preference/src/main/java/io/github/droidkaigi/confsched2020/preference/ui/viewmodel/PreferenceViewModel.kt
@@ -4,30 +4,31 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.github.droidkaigi.confsched2020.ext.combine
+import io.github.droidkaigi.confsched2020.model.NightMode
 import javax.inject.Inject
 
 class PreferenceViewModel @Inject constructor() : ViewModel() {
 
     data class UiModel(
-        val isNightMode: Boolean
+        val nightMode: NightMode
     ) {
         companion object {
-            val EMPTY = UiModel(false)
+            val EMPTY = UiModel(NightMode.SYSTEM)
         }
     }
 
-    private val nightModeLiveData: MutableLiveData<Boolean> = MutableLiveData(false)
+    private val nightModeLiveData: MutableLiveData<NightMode> = MutableLiveData(NightMode.SYSTEM)
 
     var uiModel: LiveData<UiModel> = combine(
         initialValue = UiModel.EMPTY,
         liveData1 = nightModeLiveData
-    ) { uiModel: UiModel, isNightMode: Boolean ->
+    ) { uiModel: UiModel, nightMode: NightMode ->
         UiModel(
-            isNightMode = isNightMode
+            nightMode = nightMode
         )
     }
 
-    fun setNightMode(newValue: Boolean) {
+    fun setNightMode(newValue: NightMode) {
         nightModeLiveData.value = newValue
     }
 }

--- a/feature/preference/src/main/res/xml/setting.xml
+++ b/feature/preference/src/main/res/xml/setting.xml
@@ -4,10 +4,14 @@
     <PreferenceCategory
         android:key="categoryTheme"
         android:title="@string/theme_label">
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:key="switchDarkTheme"
-            android:title="@string/dark_theme_label" />
-    </PreferenceCategory>
 
+        <ListPreference
+            android:key="darkTheme"
+            android:title="@string/dark_theme_label"
+            android:entries="@array/pref_theme_entries"
+            android:entryValues="@array/pref_theme_entry_values"
+            android:defaultValue="@string/pref_theme_value_default"
+            android:summary="%s"
+            />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/feature/preference/src/main/res/xml/setting.xml
+++ b/feature/preference/src/main/res/xml/setting.xml
@@ -10,7 +10,7 @@
             android:title="@string/dark_theme_label"
             android:entries="@array/pref_theme_entries"
             android:entryValues="@array/pref_theme_entry_values"
-            android:defaultValue="@string/pref_theme_value_default"
+            android:defaultValue="@string/pref_theme_default"
             android:summary="%s"
             />
     </PreferenceCategory>

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/NightMode.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/NightMode.kt
@@ -1,0 +1,7 @@
+package io.github.droidkaigi.confsched2020.model
+
+enum class NightMode {
+    SYSTEM,
+    YES,
+    NO,
+}

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/NightMode.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/NightMode.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2020.model
 
 enum class NightMode {
     SYSTEM,
+    BATTERY,
     YES,
     NO,
 }


### PR DESCRIPTION
## Issue
- close #466 close #560 

## Overview (Required)
- Follow system and battery option for dark theme.
    - Before once user switched dark theme in app, they no longer back to system dependent mode.
- Default value is "System default" (API 29 and above) or "When  battery saver is on" (API 28 and below).
    - App become dark when system dark setting is on (API 29 and above) or battery saver is on (all).
    - Selecting "Dark" or "Light" make app ignores both system dark setting and battery saver setting.

## Problem
- If we put preference's string resource in preference module, `App` cannot reference it. On the other hands, if we put them in base module, preference fragment needs to use them as another R class while R class of preference xml is in preference package. ([I did latter](https://github.com/DroidKaigi/conference-app-2020/pull/526/files#diff-f50804c80f18dda93732b8485c6fe46cR17))
- It is backed by preference screen's SharedPreferences. `App` references that SharedPreferences directly.

## Links
- https://medium.com/androiddevelopers/appcompat-v23-2-daynight-d10f90c83e94

## Screenshot

Before | After (API >= 29) | After (API < 29)
:--: | :--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/1487505/72969123-3cdd0680-3e08-11ea-8069-4de56b9227df.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1487505/72969265-76ae0d00-3e08-11ea-9763-8033c9c8a333.png" width="300" /> 