### PR TITLE
Change iOS deployment target

### DIFF
--- a/ios-base/project.yml
+++ b/ios-base/project.yml
@@ -5,7 +5,7 @@ targets:
     DroidKaigi 2020:
         type: application
         platform: iOS
-        deploymentTarget: "13.2"
+        deploymentTarget: "12.0"
         sources: DroidKaigi 2020
         configFiles:
             Debug: Configs/DroidKaigi 2020-Debug.xcconfig
@@ -18,11 +18,11 @@ targets:
     DroidKaigi 2020Tests:
         type: bundle.unit-test
         platform: iOS
-        deploymentTarget: "13.2"
+        deploymentTarget: "12.0"
         sources: DroidKaigi 2020Tests
     DroidKaigi 2020UITests:
         type: bundle.ui-testing
         platform: iOS
-        deploymentTarget: "13.2"
+        deploymentTarget: "12.0"
         sources: DroidKaigi 2020UITests
 


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Current iOS deployment target is too high, so I changed it to 12.0.
- I think it's enough to support the latest 2 versions.

## Links
- https://developer.apple.com/support/app-store/

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
