### PR TITLE
Fix iOS project build failed caused by SwiftLint

### DIFF
--- a/ios-base/scripts/lint.sh
+++ b/ios-base/scripts/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 git diff --name-only | grep -e '\(.*\).swift$' | while read filename; do
-  mint run swiftlint --path "$filename"
+  mint run realm/swiftlint swiftlint --path "$SRCROOT/../$filename"
 done


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- When we have some changes, iOS project build is failed by `Couldn't find executable "--path"`.  This can be fixed by specifying repository such as `realm/swiftlint` before `swiftlint` command.
<img width="394" alt="スクリーンショット 2020-01-22 3 29 56" src="https://user-images.githubusercontent.com/30540303/72832360-11530280-3cc8-11ea-86d4-d0cc11d2f066.png">

- `$filename` is not enough path for lint. This is relative path such as `ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift`. It needs to absolute path. So I changed to `$SRCROOT/../$filename`

## Links
-

## Screenshot