### PR TITLE
iOS Fix SessionCell speakerStackView height when speaker is empty

### DIFF
--- a/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.xib
+++ b/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.xib
@@ -66,7 +66,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="rMR-Ci-Z50">
                         <rect key="frame" x="76" y="65.5" width="187.5" height="40.5"/>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" id="PQ4-Ov-b0v"/>
+                            <constraint firstAttribute="height" priority="250" id="PQ4-Ov-b0v"/>
                         </constraints>
                     </stackView>
                 </subviews>


### PR DESCRIPTION
## Issue
- close #531

## Overview (Required)
- change SpeakersStackView height constraint, `greater than 0, priority=1000` to `equal 0, priority 250(Low)`
  - if stack view is not empty, child view height becomes stack view"s height.(because child view's height priority is higher than stackview's)
  - if stack view is empty, stackview's height constraint becomes highest priority.

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/875297/72856381-b4723f00-3cfd-11ea-9b3f-5d604433740e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/875297/72856799-fea7f000-3cfe-11ea-89af-d8c3e7ab6c61.png" width="300" />
