### PR TITLE
Change status bar color when slideOffset is not zero

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/widget/SystemUiManager.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/widget/SystemUiManager.kt
@@ -27,7 +27,7 @@ class SystemUiManager(
             }
         }
     private val drawerIsOpened: Boolean
-        get() = drawerSlideOffset >= DRAWER_OFFSET_OPEN_THRESHOLD
+        get() = drawerSlideOffset > 0f
 
     var isIndigoBackground: Boolean? = null
         set(value) {
@@ -93,7 +93,6 @@ class SystemUiManager(
     }
 
     companion object {
-        private const val DRAWER_OFFSET_OPEN_THRESHOLD = 0.1f
         private const val COLOR_STATUS_BAR_INVISIBLE = Color.TRANSPARENT
         private const val COLOR_STATUS_BAR_VISIBLE = 0x8a000000.toInt()
     }


### PR DESCRIPTION
## Issue
- close #463 

if I misunderstand this issue, close this PR 🙇

## Overview (Required)
- update status bar color when navigation drawer offset is not zero (greater than zero)


## Screenshot
Before | After
:--: | :--:
![before 2020-01-22 20_26_00](https://user-images.githubusercontent.com/7608725/72891105-d350ef80-3d56-11ea-9bf4-b8643dafaee6.gif) | ![after 2020-01-22 20_34_40](https://user-images.githubusercontent.com/7608725/72891119-d946d080-3d56-11ea-81b6-21f8edc54f65.gif)
