### PR TITLE
Fix time label is gone if there are over 2 sessions had same start time

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/widget/SessionsItemDecoration.kt
@@ -46,7 +46,8 @@ class SessionsItemDecoration(
             val sessionItem = adapter.getItem(position) as SessionItem
             val startTimeText = calcTimeText(position, view)
 
-            if (position > 0) {
+            // we need least first session's label, skip to check if time label is same as last item on first item.
+            if (position > 0 && index > 0) {
                 val lastSessionItem = adapter.getItem(position - 1) as SessionItem
                 if (sessionItem.startSessionTime() == lastSessionItem.startSessionTime()) return@forEachIndexed
             }


### PR DESCRIPTION
## Issue
- no issue but bug fix

## Overview (Required)
- if there are over 2 sessions had same start time, time label is gone

## Screenshot
Before | After
:--: | :--:
![time_label_before 2020-01-22 22_01_27](https://user-images.githubusercontent.com/7608725/72896299-c803c100-3d62-11ea-8646-61c3091597fa.gif) | ![time_label_after 2020-01-22 21_53_54](https://user-images.githubusercontent.com/7608725/72896178-752a0980-3d62-11ea-9734-c307383d1334.gif)

