### PR TITLE
Fix iOS can't access to api endpoint

### DIFF
--- a/ios-base/DroidKaigi 2020/Info.plist
+++ b/ios-base/DroidKaigi 2020/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>deploy-preview-49--droidkaigi-api-dev.netlify.com</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/ios-base/DroidKaigi 2020/Info.plist
+++ b/ios-base/DroidKaigi 2020/Info.plist
@@ -6,6 +6,11 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>api.droidkaigi.jp</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>deploy-preview-49--droidkaigi-api-dev.netlify.com</key>
 			<dict>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- iOS App can't access to api endpoint
- because endpoint becomes http
  - side effect of this commit #533
- to fix this issue, I changed Info.plist.

### error log
```
2020-01-22 22:27:18.876334+0900 DroidKaigi 2020[98338:9425975] App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file.
2020-01-22 22:27:18.876605+0900 DroidKaigi 2020[98338:9425975] Cannot start load of Task <94466D15-D501-457C-B2E3-696A004E3D18>.<1> since it does not conform to ATS policy
```

## Links
-

## Screenshot

