### PR TITLE
Add deeplink tester

### DIFF
--- a/android-base/build.gradle
+++ b/android-base/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     }
     debugImplementation Dep.Stetho.stetho
     debugImplementation Dep.LeakCanary.leakCanary
+    kapt Dep.Google.autoservice
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DeeplinkTester.kt
+++ b/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DeeplinkTester.kt
@@ -30,13 +30,11 @@ class DeepLinkPlugin : Plugin() {
     }
 }
 
-
 class DeepLinkDialog : DialogFragment() {
 
     companion object {
         val TAG = DeepLinkDialog::class.java.simpleName
     }
-
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -65,7 +63,6 @@ class DeepLinkDialog : DialogFragment() {
         dismiss()
         super.onPause()
     }
-
 
     private fun launchIntent(uri: String) {
         runCatching {

--- a/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DeeplinkTester.kt
+++ b/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DeeplinkTester.kt
@@ -1,0 +1,75 @@
+package io.github.droidkaigi.confsched2020
+
+import android.app.Dialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.DialogFragment
+import com.google.auto.service.AutoService
+import com.willowtreeapps.hyperion.plugin.v1.Plugin
+import com.willowtreeapps.hyperion.plugin.v1.PluginModule
+
+@AutoService(Plugin::class)
+class DeepLinkPlugin : Plugin() {
+    override fun createPluginModule() = object : PluginModule() {
+        override fun createPluginView(layoutInflater: LayoutInflater, parent: ViewGroup): View? =
+            layoutInflater.inflate(R.layout.plugin_deeplink, parent, false).apply {
+                setOnClickListener {
+                    (extension.activity as? AppCompatActivity)?.supportFragmentManager?.also {
+                        DeepLinkDialog().show(it, DeepLinkDialog.TAG)
+                    }
+                }
+            }
+    }
+}
+
+
+class DeepLinkDialog : DialogFragment() {
+
+    companion object {
+        val TAG = DeepLinkDialog::class.java.simpleName
+    }
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.dialog_deeplink, container, false)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return activity?.let {
+            val inflater = requireActivity().layoutInflater
+            val view = inflater.inflate(R.layout.dialog_deeplink, null).apply {
+                findViewById<View>(R.id.deeplink_fix_button)?.setOnClickListener {
+                    dialog?.findViewById<TextView>(R.id.deeplink_fix_input)
+                        ?.also { dom -> launchIntent(dom.text.toString()) }
+                }
+                findViewById<View>(R.id.deeplink_free_button)?.setOnClickListener {
+                    dialog?.findViewById<EditText>(R.id.deeplink_free_input)
+                        ?.also { dom -> launchIntent(dom.text.toString()) }
+                }
+            }
+            AlertDialog.Builder(it).setView(view).create()
+        } ?: throw IllegalStateException("Activity cannot be null")
+    }
+
+    override fun onPause() {
+        dismiss()
+        super.onPause()
+    }
+
+
+    private fun launchIntent(uri: String) {
+        runCatching {
+            Intent(Intent.ACTION_VIEW, Uri.parse(uri)).also { activity?.startActivity(it) }
+        }
+    }
+}

--- a/android-base/src/debug/res/layout/dialog_deeplink.xml
+++ b/android-base/src/debug/res/layout/dialog_deeplink.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/deeplink_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/deeplink_title"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/deeplink_fix_input"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="https://droidkaigi.jp/2020/announcement"
+        app:layout_constraintBottom_toBottomOf="@id/deeplink_fix_button"
+        app:layout_constraintEnd_toStartOf="@id/deeplink_fix_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/deeplink_fix_button" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/deeplink_fix_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/deeplink_action_publish"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/deeplink_title" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/deeplink_or"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/deeplink_text_or"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/deeplink_fix_button" />
+
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/deeplink_free_input"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@id/deeplink_free_button"
+        app:layout_constraintEnd_toStartOf="@id/deeplink_free_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/deeplink_free_button" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/deeplink_free_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/deeplink_action_publish"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/deeplink_or" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-base/src/debug/res/layout/plugin_deeplink.xml
+++ b/android-base/src/debug/res/layout/plugin_deeplink.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:minHeight="131dp">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="28dp"
+        android:layout_marginEnd="28dp"
+        android:text="@string/deeplink_title" />
+</FrameLayout>

--- a/android-base/src/debug/res/values/strings.xml
+++ b/android-base/src/debug/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">DK2020 Debug</string>
+
+    <string name="deeplink_action_publish">発行</string>
+    <string name="deeplink_text_or">OR</string>
+    <string name="deeplink_title">Deeplink Tester</string>
 </resources>

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -187,7 +187,8 @@ object Dep {
             "com.willowtreeapps.hyperion:hyperion-crash:$version",
             "com.willowtreeapps.hyperion:hyperion-shared-preferences:$version",
             "com.willowtreeapps.hyperion:hyperion-geiger-counter:$version",
-            "com.willowtreeapps.hyperion:hyperion-build-config:$version"
+            "com.willowtreeapps.hyperion:hyperion-build-config:$version",
+            "com.willowtreeapps.hyperion:hyperion-plugin:$version"
         )
     }
 
@@ -224,5 +225,9 @@ object Dep {
 
     object PhotoView {
         val photoview =  "com.github.chrisbanes:PhotoView:2.3.0"
+    }
+
+    object Google {
+        val autoservice = "com.google.auto.service:auto-service:1.0-rc6"
     }
 }


### PR DESCRIPTION
## Purpose
When you test deeplink, you input command like this.
I often forget it, so I want a easy way to test.

```
adb shell am start -a android.intent.action.VIEW -d "https://droidkaigi.jp/2019/announcement"
```


## How to use
1. launch app
2. shake a device or tap a hyperion notification
3. tap 'Deeplink Tester' in hyperion menu


## Note
* I wrote code in [DeeplinkTester.kt][code_tester] because it's easy to dispose it


## Links
### Related issue
* [Add deeplink support #146](https://github.com/DroidKaigi/conference-app-2020/issues/146)
* [Fix #146 Add deep-link support Announcement #250](https://github.com/DroidKaigi/conference-app-2020/pull/250)

### References
* [Hyperion-AndroidでAndroidアプリをデバッグしよう](https://qiita.com/takahirom/items/2f6557f945ddd7c5e074) (2020/01/22)
* [ダイアログ](https://developer.android.com/guide/topics/ui/dialogs?hl=ja) (2020/01/22)


[code_tester]: https://github.com/TentaShion/conference-app-2020/blob/00622afc5c11fd79c1966343f4bab784a672fa7a/android-base/src/debug/java/io/github/droidkaigi/confsched2020/DeeplinkTester.kt