### PR TITLE
Fix failed ci `found 3 errors` by Danger

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -94,7 +94,7 @@ class BottomSheetSessionsFragment : DaggerFragment() {
         binding.sessionRecycler.doOnApplyWindowInsets { sessionRecycler, insets, initialState ->
             sessionRecycler.updatePadding(bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom)
         }
-
+        // for ci check
         sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
             binding.isCollapsed = when (uiModel.expandFilterState) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -92,9 +92,11 @@ class BottomSheetSessionsFragment : DaggerFragment() {
             sessionTabViewModel.toggleExpand()
         }
         binding.sessionRecycler.doOnApplyWindowInsets { sessionRecycler, insets, initialState ->
-            sessionRecycler.updatePadding(bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom)
+            sessionRecycler.updatePadding(
+                bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+            )
         }
-        // for ci check
+
         sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
             binding.isCollapsed = when (uiModel.expandFilterState) {
@@ -105,7 +107,7 @@ class BottomSheetSessionsFragment : DaggerFragment() {
             }
         }
 
-        sessionsViewModel.uiModel.observe(viewLifecycleOwner) { uiModel: SessionsViewModel.UiModel ->
+        sessionsViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
             val page = args.page
             val sessions = when (page) {
                 is SessionPage.Day -> uiModel.dayToSessionsMap[page].orEmpty()
@@ -114,7 +116,9 @@ class BottomSheetSessionsFragment : DaggerFragment() {
             val count = sessions.filter { it.shouldCountForFilter }.count()
 
             if (page == SessionPage.Favorite) {
-                TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
+                TransitionManager.beginDelayedTransition(
+                    binding.sessionRecycler.parent as ViewGroup
+                )
                 binding.isEmptyFavoritePage = sessions.isEmpty()
             }
 

--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
@@ -128,6 +128,7 @@
                 android:id="@+id/empty_icon"
                 android:layout_width="56dp"
                 android:layout_height="72dp"
+                android:contentDescription="@null"
                 android:scaleType="centerCrop"
                 android:tint="?colorSecondary"
                 app:layout_constraintVertical_chainStyle="packed"
@@ -136,7 +137,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_bookmark_black_24dp"
-                tools:ignore="ContentDescription"
                 />
 
             <TextView


### PR DESCRIPTION
## Issue

- none

## Overview (Required)

- CI was failed by `Danger`. But content of error was not commented.
  - display error: `Danger has failed this build.  Found 3 errors.` on #440 
- I found error when run lint on local.

```
$ ./gradlew clean && ./gradlew lintDebug testDebugUnitTest ktlint --continue
$ JUNIT_TEST_RESULT_DIR=/tmp bundle exec --gemfile=.ci/Gemfile danger pr "https://github.com/DroidKaigi/conference-app-2020/pull/440" --dangerfile=".ci/danger/static_analysis.Dangerfile"

...

Results:
Errors:
- [ ] feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt#L105: Exceeded max line length (100) (cannot be auto-corrected)
- [ ] feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt#L118: Exceeded max line length (100) (cannot be auto-corrected)
- [ ] feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt#L127: Exceeded max line length (100) (cannot be auto-corrected)
Warnings:
- [ ] feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml#L71: Missing `contentDescription` attribute on image
```

- I committed `BottomSheetSessionsFragment.kt` without any code changes for failed. https://github.com/DroidKaigi/conference-app-2020/pull/544/commits/4f3b520ff4fcdceb6151c91a4ff93c6f28a6dff2
  - CI is failed: https://circleci.com/gh/DroidKaigi/conference-app-2020/634?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
- I fixed `Exceeded max line length` of `BottomSheetSessionsFragment.kt` and committed. https://github.com/DroidKaigi/conference-app-2020/pull/544/commits/4260621e76ce24dec97e548897895d6e412a8d60
  - CI is passed: https://circleci.com/gh/DroidKaigi/conference-app-2020/637?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
  - And fix ` Missing contentDescription attribute on image`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src=https://user-images.githubusercontent.com/6636072/72913030-e4fabd00-3d7f-11ea-825b-272e0ef807ea.png  width=100%> | <img src=https://user-images.githubusercontent.com/6636072/72913036-e62bea00-3d7f-11ea-84b0-56c97970b861.png  width=100%>

