### PR TITLE
bottom sheet behavior request force update

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -48,7 +48,7 @@ class SessionsFragment : DaggerFragment() {
     private var binding: FragmentSessionsBinding by autoCleared()
     private lateinit var overrideBackPressedCallback: OnBackPressedCallback
 
-    private val sessionSheetBehavior: BottomSheetBehavior<*>
+    private val sessionSheetBehavior: BottomSheetBehavior<View>
         get() {
             val layoutParams = binding.sessionsSheet.layoutParams as CoordinatorLayout.LayoutParams
             val behavior = layoutParams.behavior
@@ -113,6 +113,12 @@ class SessionsFragment : DaggerFragment() {
         binding.sessionsSheet.doOnApplyWindowInsets { _, insets, _ ->
             sessionSheetBehavior.peekHeight =
                 insets.systemWindowInsetBottom + initialPeekHeight + gestureNavigationBottomSpace
+            if (sessionSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED)
+                sessionSheetBehavior.onLayoutChild(
+                    binding.fragmentSessionsCoordinator,
+                    binding.sessionsSheet,
+                    View.LAYOUT_DIRECTION_LTR
+                )
         }
         binding.fragmentSessionsScrollView.doOnApplyWindowInsets { scrollView, insets, initialState ->
             // Set a bottom padding due to the system UI is enabled.

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -113,6 +113,8 @@ class SessionsFragment : DaggerFragment() {
         binding.sessionsSheet.doOnApplyWindowInsets { _, insets, _ ->
             sessionSheetBehavior.peekHeight =
                 insets.systemWindowInsetBottom + initialPeekHeight + gestureNavigationBottomSpace
+            // This block is the workaround to bottomSheetBehavior bug fix.
+            // https://stackoverflow.com/questions/35685681/dynamically-change-height-of-bottomsheetbehavior
             if (sessionSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED)
                 sessionSheetBehavior.onLayoutChild(
                     binding.fragmentSessionsCoordinator,


### PR DESCRIPTION
## Issue
- close #520

## Overview (Required)
- Even if peekHeight was changed, the height of BottomSheetBehavior was not recalculated, so it was recalculated.
- requestLayout() uses onLayoutChild() because the phenomenon was not resolved.
- To save computational resources, STATE_COLLAPSED has been added to work only for issues

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/40588356/72915816-43c23580-3d84-11ea-8126-29808b434f1c.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/40588356/72915744-20978600-3d84-11ea-85e3-cab2bab32e77.gif" width="300" />
