### PR TITLE
Fix color of "read more" text button

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/item/AnnouncementItem.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/item/AnnouncementItem.kt
@@ -9,7 +9,6 @@ import android.text.style.ClickableSpan
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
 import androidx.core.text.inSpans

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/item/AnnouncementItem.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/item/AnnouncementItem.kt
@@ -21,6 +21,7 @@ import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.announcement.R
 import io.github.droidkaigi.confsched2020.announcement.databinding.ItemAnnouncementBinding
+import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2020.model.Announcement
 import io.github.droidkaigi.confsched2020.model.defaultTimeZoneOffset
@@ -87,8 +88,7 @@ class AnnouncementItem @AssistedInject constructor(
                     width - ellipsisWidth,
                     TextUtils.TruncateAt.END
                 )
-                val ellipsisColor =
-                    ContextCompat.getColor(context, R.color.design_default_color_secondary)
+                val ellipsisColor = context.getThemeColor(R.attr.colorSecondary)
                 val onClickListener = {
                     TransitionManager.beginDelayedTransition(rootView as ViewGroup)
                     text = fullText

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -7,7 +7,6 @@ import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.view.View
 import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
 import androidx.core.text.inSpans

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -17,6 +17,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailDescriptionBinding
@@ -52,8 +53,7 @@ class SessionDetailDescriptionItem @AssistedInject constructor(
                 textView.width - textView.paint.measureText(ellipsis),
                 TextUtils.TruncateAt.END
             )
-            val ellipsisColor =
-                ContextCompat.getColor(context, R.color.design_default_color_secondary)
+            val ellipsisColor = context.getThemeColor(R.attr.colorSecondary)
             val onClickListener = {
                 TransitionManager.beginDelayedTransition(binding.itemRoot)
                 textView.text = fullDescription


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
Current color of "Read More" buttons are using "R.color.design_default_color_secondary" (this is secondary color of material component's light theme)
It's not same as colors of Figma design, and not consider Dark Theme.
I changed to use secondaryColor of DroidKaigi theme.

## Links
- https://www.figma.com/file/4r9becvhDy3GfXaXex8E8d/App?node-id=0%3A1

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/10704349/72951382-865e2f00-3dd1-11ea-81af-506a07c2c63b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/72951387-89591f80-3dd1-11ea-8c08-ed9a6fb480ad.png" width="300" />
<img src="https://user-images.githubusercontent.com/10704349/72951379-85c59880-3dd1-11ea-82ae-3e7953e142a1.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/72951388-89f1b600-3dd1-11ea-9ffe-99b8fe3a744d.png" width="300" />
<img src="https://user-images.githubusercontent.com/10704349/72951383-865e2f00-3dd1-11ea-9e87-55e648135642.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/72951386-89591f80-3dd1-11ea-8cfc-3ae98fc1c40d.png" width="300" />
<img src="https://user-images.githubusercontent.com/10704349/72951380-85c59880-3dd1-11ea-8431-6b1c824da071.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/72951390-89f1b600-3dd1-11ea-9cf4-0cee9f4c1f02.png" width="300" />