### PR TITLE
fix announcement link text

### DIFF
--- a/feature/announcement/src/main/res/layout/item_announcement.xml
+++ b/feature/announcement/src/main/res/layout/item_announcement.xml
@@ -49,7 +49,7 @@
             android:layout_marginTop="14dp"
             android:textColor="?colorOnBackground"
             android:textColorLink="@color/design_default_color_secondary"
-            android:autoLink="all"
+            android:autoLink="web"
             app:layout_constraintEnd_toEndOf="@+id/guideline_end"
             app:layout_constraintStart_toStartOf="@+id/announcement_title"
             app:layout_constraintTop_toBottomOf="@+id/announcement_title"

--- a/feature/announcement/src/main/res/layout/item_announcement.xml
+++ b/feature/announcement/src/main/res/layout/item_announcement.xml
@@ -48,6 +48,8 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="14dp"
             android:textColor="?colorOnBackground"
+            android:textColorLink="@color/design_default_color_secondary"
+            android:autoLink="all"
             app:layout_constraintEnd_toEndOf="@+id/guideline_end"
             app:layout_constraintStart_toStartOf="@+id/announcement_title"
             app:layout_constraintTop_toBottomOf="@+id/announcement_title"


### PR DESCRIPTION
## Issue

- close #525 

## Overview (Required)

- The TextView in announcement recyclerview analyzes link text, and it doesn't interpret html tag

## Links
-

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/937552/72988832-63af3300-3e30-11ea-87fd-a2562f4f0fc3.png) | ![after](https://user-images.githubusercontent.com/937552/72988850-7164b880-3e30-11ea-859c-f9a0c3d9efc3.png)

