### PR TITLE
Stop linting and formatting deleted files

### DIFF
--- a/ios-base/scripts/format.sh
+++ b/ios-base/scripts/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git diff --name-only | grep -e '\(.*\).swift$' | while read filename; do
+git diff --name-only --diff-filter=d | grep -e '\(.*\).swift$' | while read filename; do
   # ref: https://github.com/yonaskolb/Mint/issues/112
   mint run swiftformat swiftformat "$SRCROOT/../$filename"
 done

--- a/ios-base/scripts/lint.sh
+++ b/ios-base/scripts/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-git diff --name-only | grep -e '\(.*\).swift$' | while read filename; do
+git diff --name-only --diff-filter=d | grep -e '\(.*\).swift$' | while read filename; do
   mint run realm/swiftlint swiftlint --path "$SRCROOT/../$filename"
 done


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Linting and formatting deleted files raises an error, so this PR stop it

## Links
- https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203