### PR TITLE
Fix session list is not shown when collapse then expand quickly

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -110,12 +110,17 @@ class BottomSheetSessionsFragment : DaggerFragment() {
         }
 
         sessionTabViewModel.uiModel.observe(viewLifecycleOwner) { uiModel ->
-            TransitionManager.beginDelayedTransition(binding.sessionRecycler.parent as ViewGroup)
-            binding.isCollapsed = when (uiModel.expandFilterState) {
+            val shouldBeCollapsed = when (uiModel.expandFilterState) {
                 ExpandFilterState.COLLAPSED ->
                     true
                 else ->
                     false
+            }
+            if (binding.isCollapsed != shouldBeCollapsed) {
+                TransitionManager.beginDelayedTransition(
+                    binding.sessionRecycler.parent as ViewGroup
+                )
+                binding.isCollapsed = shouldBeCollapsed
             }
         }
 


### PR DESCRIPTION
## Issue
- close #553 

## Overview (Required)
- Sometime session list is not shown

## Cause
- Due to multiple calls of `TransitionManager.beginDelayedTransition()`

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/72947066-3cbb1780-3dc4-11ea-9900-887b35563665.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/13504295/72992817-58a7d300-3e2f-11ea-8702-d730c40708ee.gif" width="300" />
