### PR TITLE
[iOS] Improve asynchronous loading of UIImageView

### DIFF
--- a/ios-base/DroidKaigi 2020/Extentions/UIImageView+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/UIImageView+Ex.swift
@@ -1,20 +1,73 @@
 import UIKit
 
 extension UIImageView {
-    func loadImage(url: URL?) {
+    class Cache {
+        private var cache = [String: UIImage]()
+
+        fileprivate func setImage(_ image: UIImage, for key: URL) {
+            cache[key.absoluteString] = image
+        }
+
+        fileprivate func image(for key: URL) -> UIImage? {
+            return cache[key.absoluteString]
+        }
+    }
+
+    private static let imageLoadingQueue = OperationQueue()
+
+    private static var imageLoadingOperationKey = 0
+
+    private var imageLoadingOperation: Operation? {
+        get {
+            return objc_getAssociatedObject(
+                self,
+                &UIImageView.imageLoadingOperationKey
+            ) as? Operation
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &UIImageView.imageLoadingOperationKey,
+                newValue,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    func loadImage(url: URL?, using cache: Cache? = nil) {
+        image = nil
+        imageLoadingOperation?.cancel()
+        imageLoadingOperation = nil
+
         guard let url = url else {
             return
         }
-        DispatchQueue.global().async { [weak self] in
+
+        if let cachedImage = cache?.image(for: url) {
+            image = cachedImage
+            return
+        }
+
+        let operation = BlockOperation()
+        operation.addExecutionBlock { [weak self, weak operation] in
+            if let op = operation, op.isCancelled {
+                return
+            }
             do {
                 let data = try Data(contentsOf: url)
-                let image = UIImage(data: data)
-                DispatchQueue.main.async {
-                    self?.image = image
+                if let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        cache?.setImage(image, for: url)
+                        if let op = operation, !op.isCancelled {
+                            self?.image = image
+                        }
+                    }
                 }
-            } catch let e {
-                print(e.localizedDescription)
+            } catch {
+                print(error.localizedDescription)
             }
         }
+        UIImageView.imageLoadingQueue.addOperation(operation)
+        imageLoadingOperation = operation
     }
 }


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- I'm implementing issue #494. This issue's screen has image view for each collection view cells.
- I'm trying to use [this method](https://github.com/DroidKaigi/conference-app-2020/blob/884cf4e772f176fa449aac797b0a8c054852cb74/ios-base/DroidKaigi%202020/Extentions/UIImageView%2BEx.swift#L4) for image loading, but this method calls an HTTP loading every time the collection view reuses the cell.
- I added the following two features.
    - (1) Canceling image loding task: To cancel previous image loading. e.g. when reusing cells.
    - (2) Caching image: To avoid loading already loaded images again.

## Links
- [SwiftでObjective-Cの黒魔術ってどうなった？](https://qiita.com/fmtonakai/items/e9036dec4af2609b5715)
- [NSBlockOperationで手軽にキャンセル処理](https://qiita.com/ninjinkun/items/0fe8548f1debd783a04a)

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
