### PR TITLE
Floor map with dark theme

### DIFF
--- a/feature/floormap/src/main/res/layout/fragment_floormap.xml
+++ b/feature/floormap/src/main/res/layout/fragment_floormap.xml
@@ -5,7 +5,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     >
 
-    <!--TODO: Apply layout-->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -19,11 +18,11 @@
             android:src="@drawable/ic_floor_map"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
+            android:tint="?attr/colorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 </layout>


### PR DESCRIPTION
## Issue
- close #568 

## Overview (Required)
- make floormap clear enough under dark theme

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8403570/72994698-f228b200-3e3a-11ea-95ba-c414cfaddc7a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13504295/73053263-432fb900-3ec2-11ea-8a7b-7880c89f6758.png" width="600" />
