### PR TITLE
Fix sponsor item height

### DIFF
--- a/feature/sponsor/src/main/res/layout/item_sponsor.xml
+++ b/feature/sponsor/src/main/res/layout/item_sponsor.xml
@@ -22,7 +22,7 @@
             <ImageView
                 android:id="@+id/image"
                 android:layout_width="0dp"
-                android:layout_height="112dp"
+                android:layout_height="72dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- UI design of [List Sponsor](https://www.figma.com/file/4r9becvhDy3GfXaXex8E8d/App?node-id=22%3A507) says `SUPPORTER` and `TECHNICAL SUPPORT` sponsors item height is `72dp`, but actually it is `112dp`.

## Links
- N/A

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2077275/73087043-283a6480-3f15-11ea-8060-a5a7fa54902c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2077275/73087077-3ee0bb80-3f15-11ea-91ab-7124d6b084f7.png" width="300" />
