### PR TITLE
[iOS] Replace value of surfaceColor

### DIFF
--- a/ios-base/DroidKaigi 2020/ApplicationScheme.swift
+++ b/ios-base/DroidKaigi 2020/ApplicationScheme.swift
@@ -36,7 +36,7 @@ final class ApplicationScheme: NSObject {
         scheme.primaryColor = UIColor(hex: "041E42")
         scheme.onPrimaryColor = .white
         scheme.secondaryColor = UIColor(hex: "041E42")
-        scheme.surfaceColor = UIColor(hex: "041E42")
+        scheme.surfaceColor = .white
         return scheme
     }()
 }

--- a/ios-base/DroidKaigi 2020/ApplicationScheme.swift
+++ b/ios-base/DroidKaigi 2020/ApplicationScheme.swift
@@ -37,6 +37,7 @@ final class ApplicationScheme: NSObject {
         scheme.onPrimaryColor = .white
         scheme.secondaryColor = UIColor(hex: "041E42")
         scheme.surfaceColor = .white
+        scheme.onSurfaceColor = .black
         return scheme
     }()
 }

--- a/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
@@ -26,7 +26,7 @@ final class FilterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = ApplicationScheme.shared.colorScheme.surfaceColor
+        view.backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
         setUpAppBar()
         setUpTabBar()
         setUpContainerView()
@@ -71,12 +71,12 @@ final class FilterViewController: UIViewController {
                                          style: .plain,
                                          target: self,
                                          action: nil)
-        self.navigationItem.leftBarButtonItems = [menuItem, logoItem]
-        self.navigationItem.rightBarButtonItems = [searchItem]
-        self.navigationController?.navigationBar
+        navigationItem.leftBarButtonItems = [menuItem, logoItem]
+        navigationItem.rightBarButtonItems = [searchItem]
+        navigationController?.navigationBar
             .setBackgroundImage(UIImage(), for: .default)
-        self.navigationController?.navigationBar.shadowImage = UIImage()
-        self.edgesForExtendedLayout = []
+        navigationController?.navigationBar.shadowImage = UIImage()
+        edgesForExtendedLayout = []
     }
 
     private func setUpTabBar() {


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- I replaced value of `surfaceColor` with `.white`. (Refer to [Android implementation](https://github.com/DroidKaigi/conference-app-2020/blob/master/corecomponent/androidcomponent/src/main/res/values/themes.xml#L25))
- And set `onSurfaceColor` to `.black`.
- (The reason for this change is that I want to use `surfaceColor` as `.white` in [Sponsor screen](https://github.com/DroidKaigi/conference-app-2020/issues/494))

## Links
- N/A

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2077275/73112814-af0e3200-3f53-11ea-8250-91734c0a157b.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/2077275/73112822-bcc3b780-3f53-11ea-9509-eaf6245abd38.PNG" width="300" />
