### PR TITLE
[iOS] Enable unit test

### DIFF
--- a/ios-base/Gemfile
+++ b/ios-base/Gemfile
@@ -4,3 +4,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 ruby '2.6.3'
 
 gem 'cocoapods'
+gem 'xcpretty'

--- a/ios-base/Gemfile.lock
+++ b/ios-base/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
+    rouge (2.0.7)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
@@ -72,12 +73,15 @@ GEM
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.2.6)
+    xcpretty (0.3.0)
+      rouge (~> 2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cocoapods
+  xcpretty
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/ios-base/Makefile
+++ b/ios-base/Makefile
@@ -12,4 +12,4 @@ test: xcode
 	xcrun xcodebuild -workspace 'DroidKaigi 2020.xcworkspace' \
 	-scheme 'DroidKaigi 2020' \
 	-destination 'platform=iOS Simulator,name=iPhone 11' \
-	clean test | xcpretty
+	clean test | bundle exec xcpretty

--- a/ios-base/Makefile
+++ b/ios-base/Makefile
@@ -6,3 +6,10 @@ init:
 xcode:
 	mint run xcodegen
 	bundle exec pod install
+
+test: xcode
+	set -o pipefail && \
+	xcrun xcodebuild -workspace 'DroidKaigi 2020.xcworkspace' \
+	-scheme 'DroidKaigi 2020' \
+	-destination 'platform=iOS Simulator,name=iPhone 11' \
+	clean test | xcpretty

--- a/ios-base/project.yml
+++ b/ios-base/project.yml
@@ -20,11 +20,18 @@ targets:
         postBuildScripts:
             - path: scripts/format.sh
               name: "Run Format"
+        testTargets:
+            - DroidKaigi 2020Tests
     DroidKaigi 2020Tests:
         type: bundle.unit-test
         platform: iOS
         deploymentTarget: "12.0"
         sources: DroidKaigi 2020Tests
+        dependencies:
+            - target: DroidKaigi 2020
+        settings:
+            INFOPLIST_FILE: DroidKaigi 2020Tests/info.plist
+            TEST_HOST: $(BUILT_PRODUCTS_DIR)/DroidKaigi 2020.app/DroidKaigi 2020
     DroidKaigi 2020UITests:
         type: bundle.ui-testing
         platform: iOS


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Add configuration for testing with `DroidKaigi 2020Tests`
  - `⌘+U` in Xcode will be enabled.
- Add `make test` command

## Why not for UITest?
When I made both unit test and UI test, it often failed and had no ideas😭.
For this reason, I didn't use UITest.