### PR TITLE
Add event tab for sessions

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -125,6 +125,7 @@ class BottomSheetSessionsFragment : DaggerFragment() {
             val page = args.page
             val sessions = when (page) {
                 is SessionPage.Day -> uiModel.dayToSessionsMap[page].orEmpty()
+                SessionPage.Event -> listOf()
                 SessionPage.Favorite -> uiModel.favoritedSessions
             }
             val count = sessions.filter { it.shouldCountForFilter }.count()

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -137,6 +137,10 @@ class BottomSheetSessionsFragment : DaggerFragment() {
                 binding.isEmptyFavoritePage = sessions.isEmpty()
             }
 
+            if (page == SessionPage.Event) {
+                binding.isEventPage = true
+            }
+
             // For Android Lint
             @Suppress("USELESS_CAST")
             binding.filteredSessionCount.text = getString(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -125,7 +125,7 @@ class BottomSheetSessionsFragment : DaggerFragment() {
             val page = args.page
             val sessions = when (page) {
                 is SessionPage.Day -> uiModel.dayToSessionsMap[page].orEmpty()
-                SessionPage.Event -> listOf()
+                SessionPage.Event -> uiModel.events
                 SessionPage.Favorite -> uiModel.favoritedSessions
             }
             val count = sessions.filter { it.shouldCountForFilter }.count()

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
@@ -38,6 +38,7 @@ class SessionsViewModel @Inject constructor(
         val error: AppError?,
         val dayToSessionsMap: Map<SessionPage.Day, SessionList>,
         val shouldScrollSessionPosition: Map<SessionPage, Int>,
+        val events: SessionList,
         val favoritedSessions: SessionList,
         val filters: Filters,
         val allFilters: Filters
@@ -48,6 +49,7 @@ class SessionsViewModel @Inject constructor(
                 null,
                 mapOf(),
                 mapOf(),
+                SessionList.EMPTY,
                 SessionList.EMPTY,
                 Filters(),
                 Filters()
@@ -106,6 +108,7 @@ class SessionsViewModel @Inject constructor(
                 .toAppError(),
             dayToSessionsMap = dayToSessionMap,
             shouldScrollSessionPosition = shouldScrollSessionPosition,
+            events = sessions.events,
             favoritedSessions = filteredSessions.favorited,
             filters = filters,
             allFilters = Filters(

--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
@@ -17,6 +17,10 @@
         <variable
             name="isEmptyFavoritePage"
             type="Boolean" />
+
+        <variable
+            name="isEventPage"
+            type="Boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -63,7 +67,7 @@
             android:text="@string/start_filter"
             android:textAppearance="@style/TextAppearance.DroidKaigi.Body2"
             app:icon="@drawable/ic_filter_list_black_24dp"
-            app:isInvisible="@{(isEmptyFavoritePage &amp;&amp; !isFiltered) || isCollapsed}"
+            app:isInvisible="@{(isEmptyFavoritePage &amp;&amp; !isFiltered) || isCollapsed || isEventPage}"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintTop_toTopOf="parent"
             />

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Room.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Room.kt
@@ -5,4 +5,12 @@ data class Room(
     val id: Int,
     val name: LocaledString,
     val sort: Int
-) : AndroidParcel
+) : AndroidParcel {
+    companion object {
+        val EXHIBITION = Room(
+            id = 0,
+            name = LocaledString(ja = "Exhibition", en = "Exhibition"),
+            sort = 0
+        )
+    }
+}

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionList.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionList.kt
@@ -11,6 +11,10 @@ data class SessionList(private val sessions: List<Session>) : List<Session> by s
             .mapValues { (_, value) -> SessionList(value) }
     }
 
+    val events: SessionList by lazy {
+        SessionList(filter { it.room.name.ja == Room.EXHIBITION.name.ja })
+    }
+
     val favorited: SessionList by lazy {
         SessionList(filter { it.isFavorited })
     }

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
@@ -3,6 +3,10 @@ package io.github.droidkaigi.confsched2020.model
 @AndroidParcelize
 sealed class SessionPage : AndroidParcel {
 
+    object Event : SessionPage() {
+        override val title = "Event"
+    }
+
     object Favorite : SessionPage() {
         override val title = "My Plan"
     }
@@ -18,7 +22,7 @@ sealed class SessionPage : AndroidParcel {
     abstract val title: String
 
     companion object {
-        val pages = listOf(Day1, Day2, Favorite)
+        val pages = listOf(Day1, Day2, Event, Favorite)
 
         fun dayOfNumber(dayNumber: Int): Day {
             return pages.filterIsInstance<Day>().first { it.day == dayNumber }


### PR DESCRIPTION
## Issue
- #554 

## Overview (Required)
- Add Event Tab for sessions and bind the data of the room named Exhibition that is included in the data of the list of Sessions.

## Links
- https://www.figma.com/file/4r9becvhDy3GfXaXex8E8d/App?node-id=1279%3A1339

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/56813210/73115531-7cbbff00-3f6a-11ea-89a0-56ce35d37017.png" width="300" /> | <img src="https://user-images.githubusercontent.com/56813210/73115532-7e85c280-3f6a-11ea-9049-3e796fc05dc6.png" width="300" />
