### PR TITLE
`post-checkout` for iOS project

### DIFF
--- a/ios-base/Makefile
+++ b/ios-base/Makefile
@@ -1,7 +1,13 @@
+GIT_REPO = $(shell git rev-parse --show-toplevel)
+GIT_DIR = $(shell git rev-parse --git-dir)
+
 init:
 	mint run xcodegen
 	bundle install --path vendor/bundle
 	bundle exec pod install
+
+hooks:
+	@cp $(GIT_REPO)/ios-base/scripts/git-hooks/* $(GIT_DIR)/hooks
 
 xcode:
 	mint run xcodegen

--- a/ios-base/Makefile
+++ b/ios-base/Makefile
@@ -5,8 +5,6 @@ init:
 	mint run xcodegen
 	bundle install --path vendor/bundle
 	bundle exec pod install
-
-hooks:
 	@cp $(GIT_REPO)/ios-base/scripts/git-hooks/* $(GIT_DIR)/hooks
 
 xcode:

--- a/ios-base/scripts/git-hooks/post-checkout
+++ b/ios-base/scripts/git-hooks/post-checkout
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+PREV_COMMIT=$1
+POST_COMMIT=$2
+
+DIFF=$(git diff $PREV_COMMIT..$POST_COMMIT --name-status --diff-filter=ADR | grep 'ios-base/DroidKaigi 2020')
+if [[ $DIFF != "" ]]; then
+    while read line
+    do
+        echo "$line"
+    done <<END
+    $DIFF
+END
+    echo 'File added/deleted in ios-base. Re-run xcodegen'
+    make -C "$(git rev-parse --show-toplevel)/ios-base" xcode
+fi


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
iOS project is using XcodeGen.
When switching branch or rebase from origin/master and there is file addition/deletion,
we needs to re-run `xcodegen`.
This PR makes it doing automatically.

## Links
- [XcodeGenを導入してハマったこと](https://qiita.com/417_72ki/items/b23db0e26ae740d1132d#%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E3%82%92%E5%88%87%E3%82%8A%E6%9B%BF%E3%81%88%E3%82%8B%E9%9A%9B%E3%81%AB%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%8C%E8%BF%BD%E5%8A%A0%E5%89%8A%E9%99%A4%E3%81%95%E3%82%8C%E3%81%A6%E3%81%84%E3%81%A6%E3%82%82%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AB%E5%8F%8D%E6%98%A0%E3%81%95%E3%82%8C%E3%81%AA%E3%81%84)

