### PR TITLE
Delete test module use when not test

### DIFF
--- a/feature/staff/build.gradle
+++ b/feature/staff/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation project(':feature:system')
 
     implementation project(':corecomponent:androidcomponent')
-    implementation project(':corecomponent:androidtestcomponent')
     implementation project(":data:repository")
 
     implementation Dep.Kotlin.stdlibJvm
@@ -26,7 +25,6 @@ dependencies {
     implementation Dep.AndroidX.recyclerView
     implementation Dep.AndroidX.emoji
     implementation Dep.AndroidX.design
-
 
     implementation Dep.Dagger.core
     implementation Dep.Dagger.androidSupport
@@ -40,11 +38,11 @@ dependencies {
 
     implementation Dep.Coil.coil
 
+    testImplementation project(':corecomponent:androidtestcomponent')
     testImplementation Dep.Test.junit
     testImplementation Dep.Test.kotlinTestAssertions
     testImplementation Dep.MockK.jvm
     androidTestImplementation Dep.Test.testRunner
     androidTestImplementation Dep.Test.espressoCore
 }
-
 


### PR DESCRIPTION
## Issue
- close #591

## Overview (Required)
- Coroutines dispatchers are changed when the staff module. So I fixed it

base
![image](https://user-images.githubusercontent.com/1386930/73116638-f6f57f00-3f7c-11ea-902a-19fbcc9c207e.png)
staff
![image](https://user-images.githubusercontent.com/1386930/73116647-0c6aa900-3f7d-11ea-9bf9-c05eac7b6b82.png)


## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
