### PR TITLE
[iOS] Enable view controller-based status bar appearance

### DIFF
--- a/ios-base/DroidKaigi 2020/AppDelegate.swift
+++ b/ios-base/DroidKaigi 2020/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             UINavigationBar.appearance().tintColor = ApplicationScheme.shared.colorScheme.onPrimaryColor
             UINavigationBar.appearance().backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
             let vc = FilterViewController()
-            let nvc = UINavigationController(rootViewController: vc)
+            let nvc = NavigationController(rootViewController: vc)
             nvc.view.backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
             window.rootViewController = nvc
             self.window = window

--- a/ios-base/DroidKaigi 2020/Common/NavigationController.swift
+++ b/ios-base/DroidKaigi 2020/Common/NavigationController.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+final class NavigationController: UINavigationController {
+    override var childForStatusBarStyle: UIViewController? {
+        return visibleViewController
+    }
+}

--- a/ios-base/DroidKaigi 2020/Info.plist
+++ b/ios-base/DroidKaigi 2020/Info.plist
@@ -73,6 +73,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/ios-base/DroidKaigi 2020/SceneDelegate.swift
+++ b/ios-base/DroidKaigi 2020/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         UINavigationBar.appearance().tintColor = ApplicationScheme.shared.colorScheme.onPrimaryColor
         UINavigationBar.appearance().backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
         let vc = FilterViewController()
-        let nvc = UINavigationController(rootViewController: vc)
+        let nvc = NavigationController(rootViewController: vc)
         nvc.view.backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
         window.rootViewController = nvc
         self.window = window

--- a/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
@@ -23,6 +23,10 @@ final class FilterViewController: UIViewController {
 
     private let embeddedViewAnimator = UIViewPropertyAnimator(duration: 0.8, curve: .easeInOut)
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- This app has both the dark screen and the bright screen with the status bar part. So I enabled view controller-based status bar appearance.

## Links
- [ステータスバーのスタイル(色)変更方法優先度 まとめ](https://qiita.com/ux_design_tokyo/items/8e62977b7609e68755c7)

## Screenshot
### Session
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2077275/73117799-6fb10700-3f8e-11ea-9d52-16992ff36aa9.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/2077275/73117803-7b9cc900-3f8e-11ea-996e-88ae5818b94f.PNG" width="300" />

### Sponsor (Under development at #597)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2077275/73117819-9707d400-3f8e-11ea-8ec9-260317092cb6.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/2077275/73117823-a424c300-3f8e-11ea-8999-225a22c3ae0e.PNG" width="300" />
