### PR TITLE
Fix filter_now to support English

### DIFF
--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="session_on_going">ON GOING</string>
     <string name="start_filter">Filter</string>
-    <string name="filter_now">絞り込み中</string>
+    <string name="filter_now">Filtering</string>
     <string name="intended_audience_title">Intended audience</string>
     <string name="session_share" translatable="false">Share</string>
     <string name="applicable_session">Applicable session: %1$d</string>


### PR DESCRIPTION
## Issue
- close #579 

## Overview (Required)
- I fixed filter_now value from "絞り込み中" to Filtering

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/28699251/73118047-ce2bb480-3f91-11ea-84b0-51544ea259ef.png" width="300" /> | <img src="https://user-images.githubusercontent.com/28699251/73118054-da177680-3f91-11ea-9436-fad2e254ebae.png" width="300" />
