### PR TITLE
Expand ripple effect for speaker

### DIFF
--- a/feature/session/src/main/res/layout/item_session_detail_speaker.xml
+++ b/feature/session/src/main/res/layout/item_session_detail_speaker.xml
@@ -11,6 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
+        android:background="?attr/selectableItemBackground"
         app:layout_constraintEnd_toStartOf="@+id/guideline_end"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toTopOf="parent">
@@ -18,7 +19,6 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
             tools:ignore="UselessParent"
             >
 


### PR DESCRIPTION
## Issue

Nothing

## Overview (Required)
- We can tap all of the line of speaker in session detail, but ripple effect is only for speaker icon and name 

## Links

Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1650277/73118286-6e370d00-3f95-11ea-8ade-59036297709f.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1650277/73118288-70996700-3f95-11ea-89f3-8cd6df006533.gif" width="300" />

