### PR TITLE
Removed duplicate dependencies

### DIFF
--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     api Dep.Insetter.insetter
 
     implementation Dep.Dagger.androidSupport
-    implementation Dep.Kotlin.stdlibJvm
     api Dep.Kotlin.coroutines
 
     api Dep.AndroidX.Navigation.runtimeKtx

--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -28,8 +28,6 @@ dependencies {
     api Dep.AndroidX.Navigation.fragmentKtx
     api Dep.AndroidX.Navigation.uiKtx
 
-    implementation Dep.AndroidX.liveDataKtx
-
     implementation Dep.Ktor.clientAndroid
     implementation Dep.Firebase.firestoreKtx
     implementation Dep.Firebase.auth


### PR DESCRIPTION
## Issue
N/A

## Overview (Required)
-  Removed duplicate dependencies
    - in build.gradle(:corecomponent:androidcomponent), there are duplicate dependencies for `Dep.Kotlin.stdlibJvm`  and `Dep.AndroidX.liveDataKtx` .
         - is it ok to leave dependency for `liveDataKtx` with `api` ?

## Links
N/A

## Screenshot
N/A
