### PR TITLE
Fix SessionPage parcelize crash

### DIFF
--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
@@ -3,10 +3,12 @@ package io.github.droidkaigi.confsched2020.model
 @AndroidParcelize
 sealed class SessionPage : AndroidParcel {
 
+    @AndroidParcelize
     object Event : SessionPage() {
         override val title = "Event"
     }
 
+    @AndroidParcelize
     object Favorite : SessionPage() {
         override val title = "My Plan"
     }
@@ -16,7 +18,10 @@ sealed class SessionPage : AndroidParcel {
         val day: Int
     ) : SessionPage()
 
+    @AndroidParcelize
     object Day1 : Day("Day 1", 1)
+
+    @AndroidParcelize
     object Day2 : Day("Day 2", 2)
 
     abstract val title: String

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionPage.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020.model
 
-@AndroidParcelize
 sealed class SessionPage : AndroidParcel {
 
     @AndroidParcelize
@@ -13,6 +12,7 @@ sealed class SessionPage : AndroidParcel {
         override val title = "My Plan"
     }
 
+    @AndroidParcelize
     open class Day(
         override val title: String,
         val day: Int


### PR DESCRIPTION
## Issue
- #610 

## Overview (Required)
- Added `AndroidParcelize` for subclasses of `SessionPage` because of Parcelize clash.
Perhaps it's no longer crashed.

#### Env:
- Device : Pixel 3a
- OS : 10.0

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
