### PR TITLE
Add retry on Contributors screen

### DIFF
--- a/feature/contributor/build.gradle
+++ b/feature/contributor/build.gradle
@@ -11,7 +11,6 @@ apply from: rootProject.file('gradle/android-dynamic-module.gradle')
 dependencies {
     implementation project(':android-base')
 
-    implementation project(':feature:system')
     implementation project(':corecomponent:androidcomponent')
     implementation project(":data:repository")
 

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/viewmodel/ContributorsViewModel.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/viewmodel/ContributorsViewModel.kt
@@ -1,16 +1,21 @@
 package io.github.droidkaigi.confsched2020.contributor.ui.viewmodel
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
+import androidx.lifecycle.viewModelScope
 import io.github.droidkaigi.confsched2020.ext.combine
+import io.github.droidkaigi.confsched2020.ext.dropWhileIndexed
 import io.github.droidkaigi.confsched2020.ext.toAppError
 import io.github.droidkaigi.confsched2020.ext.toLoadingState
 import io.github.droidkaigi.confsched2020.model.AppError
 import io.github.droidkaigi.confsched2020.model.Contributor
 import io.github.droidkaigi.confsched2020.model.LoadState
+import io.github.droidkaigi.confsched2020.model.LoadingState
 import io.github.droidkaigi.confsched2020.model.repository.ContributorRepository
+import kotlinx.coroutines.launch
 import java.lang.Exception
 import javax.inject.Inject
 
@@ -33,6 +38,9 @@ class ContributorsViewModel @Inject constructor(
     private val contributorsLoadStateLiveData: LiveData<LoadState<List<Contributor>>> = liveData {
         emitSource(
             contributorRepository.contributorContents()
+                .dropWhileIndexed { index, value ->
+                    isEmptyCache(index, value)
+                }
                 .toLoadingState()
                 .asLiveData()
         )
@@ -40,21 +48,40 @@ class ContributorsViewModel @Inject constructor(
         try {
             contributorRepository.refresh()
         } catch (exception: Exception) {
-            // We can show contributors with cache
+            reloadContributorsLiveData.value = LoadingState.Error(exception)
         }
     }
+    private val reloadContributorsLiveData = MutableLiveData<LoadingState>(LoadingState.Loaded)
 
     val uiModel: LiveData<UiModel> = combine(
         initialValue = UiModel.EMPTY,
-        liveData1 = contributorsLoadStateLiveData
-    ) { _, loadState ->
+        liveData1 = contributorsLoadStateLiveData,
+        liveData2 = reloadContributorsLiveData
+    ) { _, loadState, reloadState ->
         if (loadState is LoadState.Loaded) {
             contributors = loadState.value
         }
+        val appError = reloadState.getErrorIfExists()?.toAppError()
+            ?: loadState.getErrorIfExists()?.toAppError()
         UiModel(
-            isLoading = loadState.isLoading,
-            error = loadState.getErrorIfExists()?.toAppError(),
+            isLoading = (loadState.isLoading || reloadState.isLoading) && appError == null,
+            error = appError,
             contributors = contributors
         )
     }
+
+    fun onRetry() {
+        reloadContributorsLiveData.value = LoadingState.Loading
+        viewModelScope.launch {
+            try {
+                contributorRepository.refresh()
+                reloadContributorsLiveData.value = LoadingState.Loaded
+            } catch (exception: Exception) {
+                reloadContributorsLiveData.value = LoadingState.Error(exception)
+            }
+        }
+    }
+
+    private fun isEmptyCache(index: Int, value: List<Contributor>): Boolean =
+        index == 0 && value.isEmpty()
 }

--- a/feature/contributor/src/main/res/layout/fragment_contributors.xml
+++ b/feature/contributor/src/main/res/layout/fragment_contributors.xml
@@ -30,6 +30,17 @@
             android:layout_gravity="center"
             />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/retry_button"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            android:text="@string/retry_label"
+            tools:visibility="visible"
+            />
+
     </FrameLayout>
 
 </layout>

--- a/feature/contributor/src/main/res/values-ja/strings.xml
+++ b/feature/contributor/src/main/res/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="retry_label">リトライ</string>
+</resources>

--- a/feature/contributor/src/main/res/values/strings.xml
+++ b/feature/contributor/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="retry_label">Retry</string>
+</resources>


### PR DESCRIPTION
## Issue
- No Issue filed
- Follow-up from #115 

## Overview (Required)
- Allow the user to retry reloading the data when the API call fails.

Before:
- Problem 1: When no cache exists and the API call fails, there's no way to reload the Contributors screen unless you exit and re-enter the Contributors screen.
- Problem 2: The loading indicator gets dismissed as soon as the repository loads data from DB regardless of whether cache exists or not. The app then starts an API call which could make the user wait for some time on a blank screen without any loading indicator until the API call completes.

After:
- When the API call fails, if there's no cache to show any data, then show a retry button. If cache exists, then show the retry option on the snackbar while displaying the current data.
- Loading indicator continues to be displayed until either real data is retrieved or an error occurs. 

## Screenshot
Note:
- Airplane mode is enabled in the beginning of the videos to simulate network errors.
- Added a delay of 3s to the API calls to simulate slow network connection.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3074663/73129015-15fd0c80-3f8f-11ea-83df-29bc15f7e5f1.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3074663/73129013-14cbdf80-3f8f-11ea-9f2e-973a7da89ab4.gif" width="300" />

Error when contributors cache exists:
<img src="https://user-images.githubusercontent.com/3074663/73129859-c5db7580-3fa1-11ea-87e6-c90eade5d3cc.png" width="300" />
