### PR TITLE
Automate Dagger injection & Use Fragment LayoutId constructor

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/App.kt
@@ -8,6 +8,7 @@ import dagger.android.AndroidInjector
 import dagger.android.DaggerApplication
 import io.github.droidkaigi.confsched2020.di.AppComponent
 import io.github.droidkaigi.confsched2020.di.AppComponentHolder
+import io.github.droidkaigi.confsched2020.di.AppInjector
 import io.github.droidkaigi.confsched2020.di.createAppComponent
 import io.github.droidkaigi.confsched2020.image.CoilInitializer
 import io.github.droidkaigi.confsched2020.util.Prefs
@@ -26,10 +27,15 @@ open class App : DaggerApplication(), AppComponentHolder {
 
     override fun onCreate() {
         super.onCreate()
+        setupAppInjector()
         setupTimber()
         setupFirestore()
         setupNightMode()
         setupCoil()
+    }
+
+    private fun setupAppInjector() {
+        AppInjector.initialize(this)
     }
 
     private fun setupTimber() {

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.IdRes
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.GravityCompat
@@ -25,8 +26,10 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.snackbar.Snackbar
 import dagger.Binds
 import dagger.Module
+import dagger.android.AndroidInjector
 import dagger.android.ContributesAndroidInjector
-import dagger.android.support.DaggerAppCompatActivity
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.about.ui.AboutFragment
 import io.github.droidkaigi.confsched2020.about.ui.AboutFragmentModule
@@ -66,7 +69,7 @@ import javax.inject.Provider
 import timber.log.Timber
 import timber.log.warn
 
-class MainActivity : DaggerAppCompatActivity() {
+class MainActivity : AppCompatActivity(), HasAndroidInjector {
     private val binding: ActivityMainBinding by lazy {
         DataBindingUtil.setContentView<ActivityMainBinding>(
             this,
@@ -87,6 +90,11 @@ class MainActivity : DaggerAppCompatActivity() {
     private val statusBarColors: SystemUiManager by lazy {
         SystemUiManager(this)
     }
+
+    @Inject
+    lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppComponent.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppComponent.kt
@@ -3,8 +3,8 @@ package io.github.droidkaigi.confsched2020.di
 import android.app.Application
 import dagger.BindsInstance
 import dagger.Component
+import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
-import dagger.android.support.AndroidSupportInjectionModule
 import io.github.droidkaigi.confsched2020.App
 import io.github.droidkaigi.confsched2020.MainActivityModule
 import io.github.droidkaigi.confsched2020.model.repository.ContributorRepository
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         AppModule::class,
-        AndroidSupportInjectionModule::class,
+        AndroidInjectionModule::class,
         MainActivityModule.MainActivityBuilder::class,
         DbComponentModule::class,
         RepositoryComponentModule::class,

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
@@ -67,5 +67,3 @@ object AppInjector {
         }
     }
 }
-
-

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
@@ -1,0 +1,71 @@
+package io.github.droidkaigi.confsched2020.di
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import dagger.android.AndroidInjection
+import dagger.android.HasAndroidInjector
+import dagger.android.support.AndroidSupportInjection
+
+object AppInjector {
+    fun initialize(application: Application) {
+        application.registerActivityLifecycleCallbacks(
+            object : Application.ActivityLifecycleCallbacks {
+
+                override fun onActivityCreated(
+                    activity: Activity,
+                    savedInstanceState: Bundle?
+                ) {
+                    handleActivity(activity)
+                }
+
+                override fun onActivityStarted(activity: Activity) {
+                }
+
+                override fun onActivityResumed(activity: Activity) {
+                }
+
+                override fun onActivityPaused(activity: Activity) {
+                }
+
+                override fun onActivityStopped(activity: Activity) {
+                }
+
+                override fun onActivitySaveInstanceState(
+                    activity: Activity,
+                    outState: Bundle?
+                ) {
+                }
+
+                override fun onActivityDestroyed(activity: Activity) {
+                }
+            })
+    }
+
+    private fun handleActivity(activity: Activity) {
+        if (activity is HasAndroidInjector) {
+            AndroidInjection.inject(activity)
+        }
+        if (activity is FragmentActivity) {
+            activity.supportFragmentManager.registerFragmentLifecycleCallbacks(
+                object : FragmentManager.FragmentLifecycleCallbacks() {
+                    override fun onFragmentPreAttached(
+                        fm: FragmentManager,
+                        f: Fragment,
+                        context: Context
+                    ) {
+                        if (f is Injectable) {
+                            AndroidSupportInjection.inject(f)
+                        }
+                    }
+                }, true
+            )
+        }
+    }
+}
+
+

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/di/AppInjector.kt
@@ -58,7 +58,7 @@ object AppInjector {
                         f: Fragment,
                         context: Context
                     ) {
-                        if (f is Injectable) {
+                        if (f is Injectable || f is HasAndroidInjector) {
                             AndroidSupportInjection.inject(f)
                         }
                     }

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/di/Injectable.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/di/Injectable.kt
@@ -1,4 +1,3 @@
 package io.github.droidkaigi.confsched2020.di
 
-interface Injectable {
-}
+interface Injectable

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/di/Injectable.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/di/Injectable.kt
@@ -1,0 +1,4 @@
+package io.github.droidkaigi.confsched2020.di
+
+interface Injectable {
+}

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.about.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -14,7 +12,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.about.R
 import io.github.droidkaigi.confsched2020.about.databinding.FragmentAboutBinding
@@ -28,7 +25,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AboutFragment : Fragment(), Injectable {
+class AboutFragment : Fragment(R.layout.fragment_about), Injectable {
 
     @Inject
     lateinit var aboutModelFactory: AboutViewModel.Factory
@@ -40,18 +37,6 @@ class AboutFragment : Fragment(), Injectable {
     lateinit var systemViewModelProvider: Provider<SystemViewModel>
     private val systemViewModel: SystemViewModel by assistedActivityViewModels {
         systemViewModelProvider.get()
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_about,
-            container,
-            false
-        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.Navigation
@@ -18,6 +19,7 @@ import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.about.R
 import io.github.droidkaigi.confsched2020.about.databinding.FragmentAboutBinding
 import io.github.droidkaigi.confsched2020.about.ui.viewmodel.AboutViewModel
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -26,7 +28,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AboutFragment : DaggerFragment() {
+class AboutFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var aboutModelFactory: AboutViewModel.Factory

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -2,9 +2,7 @@ package io.github.droidkaigi.confsched2020.announcement.ui
 
 import android.graphics.Rect
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -16,7 +14,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.announcement.R
 import io.github.droidkaigi.confsched2020.announcement.databinding.FragmentAnnouncementBinding
@@ -31,7 +28,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AnnouncementFragment : Fragment(), Injectable {
+class AnnouncementFragment : Fragment(R.layout.fragment_announcement), Injectable {
 
     @Inject
     lateinit var announcementModelFactory: AnnouncementViewModel.Factory
@@ -47,18 +44,6 @@ class AnnouncementFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var announcementItemFactory: AnnouncementItem.Factory
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(
-            R.layout.fragment_announcement,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -21,6 +22,7 @@ import io.github.droidkaigi.confsched2020.announcement.R
 import io.github.droidkaigi.confsched2020.announcement.databinding.FragmentAnnouncementBinding
 import io.github.droidkaigi.confsched2020.announcement.ui.item.AnnouncementItem
 import io.github.droidkaigi.confsched2020.announcement.ui.viewmodel.AnnouncementViewModel
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -29,7 +31,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class AnnouncementFragment : DaggerFragment() {
+class AnnouncementFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var announcementModelFactory: AnnouncementViewModel.Factory

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.contributor.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -30,7 +28,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class ContributorsFragment : Fragment() {
+class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
 
     @Inject lateinit var contributorsFactory: Provider<ContributorsViewModel>
     private val contributorsViewModel by assistedViewModels {
@@ -41,18 +39,6 @@ class ContributorsFragment : Fragment() {
         systemViewModelProvider.get()
     }
     @Inject lateinit var contributorItemFactory: ContributorItem.Factory
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_contributors,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -1,9 +1,5 @@
 package io.github.droidkaigi.confsched2020.floormap.ui
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -14,19 +10,7 @@ import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.floormap.R
 
 // TODO: Apply the floor map UI
-class FloorMapFragment : Fragment(), Injectable {
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(
-            R.layout.fragment_floormap,
-            container,
-            false
-        )
-    }
+class FloorMapFragment : Fragment(R.layout.fragment_floormap), Injectable {
 
     @Module
     abstract class FloorMapFragmentModule {

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -4,16 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.floormap.R
 
 // TODO: Apply the floor map UI
-class FloorMapFragment : DaggerFragment() {
+class FloorMapFragment : Fragment(), Injectable {
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -33,7 +32,7 @@ import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import javax.inject.Inject
 import javax.inject.Provider
 
-class BottomSheetSessionsFragment : Fragment(), Injectable {
+class BottomSheetSessionsFragment : Fragment(R.layout.fragment_bottom_sheet_sessions), Injectable {
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -58,18 +57,6 @@ class BottomSheetSessionsFragment : Fragment(), Injectable {
     lateinit var sessionItemFactory: SessionItem.Factory
     private val args: BottomSheetSessionsFragmentArgs by lazy {
         BottomSheetSessionsFragmentArgs.fromBundle(arguments ?: Bundle())
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_bottom_sheet_sessions,
-            container,
-            false
-        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -16,8 +17,8 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.model.ExpandFilterState
@@ -32,7 +33,7 @@ import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import javax.inject.Inject
 import javax.inject.Provider
 
-class BottomSheetSessionsFragment : DaggerFragment() {
+class BottomSheetSessionsFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -1,12 +1,10 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -37,7 +35,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class MainSessionsFragment : Fragment(), HasAndroidInjector {
+class MainSessionsFragment : Fragment(R.layout.fragment_main_sessions), HasAndroidInjector {
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -58,21 +56,9 @@ class MainSessionsFragment : Fragment(), HasAndroidInjector {
 
     override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        setHasOptionsMenu(true)
-        return inflater.inflate(
-            R.layout.fragment_main_sessions,
-            container,
-            false
-        )
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
         val binding = FragmentMainSessionsBinding.bind(view)
         setupSessionPager(binding)
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -19,8 +19,10 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.soywiz.klock.DateTime
 import dagger.Module
 import dagger.Provides
+import dagger.android.AndroidInjector
 import dagger.android.ContributesAndroidInjector
-import dagger.android.support.DaggerFragment
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.model.SessionPage
@@ -35,7 +37,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class MainSessionsFragment : DaggerFragment() {
+class MainSessionsFragment : Fragment(), HasAndroidInjector {
 
     @Inject
     lateinit var sessionsViewModelProvider: Provider<SessionsViewModel>
@@ -50,6 +52,11 @@ class MainSessionsFragment : DaggerFragment() {
 
     @Inject
     lateinit var sessionItemFactory: SessionItem.Factory
+
+    @Inject
+    lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -19,8 +20,8 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -40,7 +41,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SearchSessionsFragment : DaggerFragment() {
+class SearchSessionsFragment : Fragment(), Injectable {
 
     @Inject lateinit var searchSessionsModelFactory: SearchSessionsViewModel.Factory
     private val searchSessionsViewModel by assistedViewModels {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -2,11 +2,9 @@ package io.github.droidkaigi.confsched2020.session.ui
 
 import android.app.Activity
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import androidx.appcompat.content.res.AppCompatResources
@@ -41,7 +39,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SearchSessionsFragment : Fragment(), Injectable {
+class SearchSessionsFragment : Fragment(R.layout.fragment_search_sessions), Injectable {
 
     @Inject lateinit var searchSessionsModelFactory: SearchSessionsViewModel.Factory
     private val searchSessionsViewModel by assistedViewModels {
@@ -70,18 +68,6 @@ class SearchSessionsFragment : Fragment(), Injectable {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_search_sessions,
-            container,
-            false
-        )
     }
 
     override fun onDestroyView() {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.annotation.IdRes
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -45,7 +43,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionDetailFragment : Fragment(), Injectable {
+class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Injectable {
 
     @Inject lateinit var systemViewModelFactory: Provider<SystemViewModel>
     private val systemViewModel by assistedActivityViewModels {
@@ -80,18 +78,6 @@ class SessionDetailFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var sessionDetailMaterialItemFactory: SessionDetailMaterialItem.Factory
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_session_detail,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -19,7 +20,7 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -44,7 +45,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionDetailFragment : DaggerFragment() {
+class SessionDetailFragment : Fragment(), Injectable {
 
     @Inject lateinit var systemViewModelFactory: Provider<SystemViewModel>
     private val systemViewModel by assistedActivityViewModels {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -3,9 +3,7 @@ package io.github.droidkaigi.confsched2020.session.ui
 import android.content.res.Resources
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.core.view.children
@@ -44,7 +42,7 @@ import io.github.droidkaigi.confsched2020.ui.widget.onCheckedChanged
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionsFragment : Fragment(), HasAndroidInjector {
+class SessionsFragment : Fragment(R.layout.fragment_sessions), HasAndroidInjector {
 
     private lateinit var overrideBackPressedCallback: OnBackPressedCallback
 
@@ -84,21 +82,9 @@ class SessionsFragment : Fragment(), HasAndroidInjector {
             }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        setHasOptionsMenu(true)
-        return inflater.inflate(
-            R.layout.fragment_sessions,
-            container,
-            false
-        )
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setHasOptionsMenu(true)
         val binding = FragmentSessionsBinding.bind(view)
         val sessionSheetBehavior = BottomSheetBehavior.from(binding.sessionsSheet)
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -10,6 +10,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.core.view.children
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -22,8 +23,10 @@ import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import dagger.Module
 import dagger.Provides
+import dagger.android.AndroidInjector
 import dagger.android.ContributesAndroidInjector
-import dagger.android.support.DaggerFragment
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.HasAndroidInjector
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -41,7 +44,7 @@ import io.github.droidkaigi.confsched2020.ui.widget.onCheckedChanged
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionsFragment : DaggerFragment() {
+class SessionsFragment : Fragment(), HasAndroidInjector {
 
     private lateinit var overrideBackPressedCallback: OnBackPressedCallback
 
@@ -64,6 +67,11 @@ class SessionsFragment : DaggerFragment() {
     private val args: SessionsFragmentArgs by lazy {
         SessionsFragmentArgs.fromBundle(arguments ?: Bundle())
     }
+
+    @Inject
+    lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    override fun androidInjector(): AndroidInjector<Any> = androidInjector
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
@@ -16,7 +17,7 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
 import io.github.droidkaigi.confsched2020.session.R
@@ -28,7 +29,7 @@ import io.github.droidkaigi.confsched2020.util.AndroidRTransition
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 
-class SpeakerFragment : DaggerFragment() {
+class SpeakerFragment : Fragment(), Injectable {
 
     @Inject lateinit var speakerViewModelFactory: SpeakerViewModel.Factory
     private val speakerViewModel by assistedViewModels {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.session.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -29,7 +27,7 @@ import io.github.droidkaigi.confsched2020.util.AndroidRTransition
 import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 
-class SpeakerFragment : Fragment(), Injectable {
+class SpeakerFragment : Fragment(R.layout.fragment_speaker), Injectable {
 
     @Inject lateinit var speakerViewModelFactory: SpeakerViewModel.Factory
     private val speakerViewModel by assistedViewModels {
@@ -47,18 +45,6 @@ class SpeakerFragment : Fragment(), Injectable {
             .inflateTransition(AndroidRTransition.move).apply {
                 interpolator = AccelerateDecelerateInterpolator()
             }
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_speaker,
-            container,
-            false
-        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -5,12 +5,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.navigation.fragment.navArgs
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -22,7 +23,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionSurveyFragment : DaggerFragment() {
+class SessionSurveyFragment : Fragment(), Injectable {
 
     @Inject
     lateinit var sessionSurveyModelFactory: SessionSurveyViewModel.Factory

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.session_survey.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -23,7 +21,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SessionSurveyFragment : Fragment(), Injectable {
+class SessionSurveyFragment : Fragment(R.layout.fragment_session_survey), Injectable {
 
     @Inject
     lateinit var sessionSurveyModelFactory: SessionSurveyViewModel.Factory
@@ -38,18 +36,6 @@ class SessionSurveyFragment : Fragment(), Injectable {
     }
 
     private val navArgs: SessionSurveyFragmentArgs by navArgs()
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_session_survey,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.observe
@@ -15,7 +16,7 @@ import com.xwray.groupie.Section
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.DaggerFragment
+import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -33,7 +34,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SponsorsFragment : DaggerFragment() {
+class SponsorsFragment : Fragment(), Injectable {
 
     @Inject lateinit var sponsorsModelFactory: Provider<SponsorsViewModel>
     private val sponsorsViewModel by assistedViewModels {

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.sponsor.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -34,7 +32,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class SponsorsFragment : Fragment(), Injectable {
+class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
 
     @Inject lateinit var sponsorsModelFactory: Provider<SponsorsViewModel>
     private val sponsorsViewModel by assistedViewModels {
@@ -50,18 +48,6 @@ class SponsorsFragment : Fragment(), Injectable {
     @Inject lateinit var sponsorItemFactory: SponsorItem.Factory
 
     @Inject lateinit var categoryHeaderItemFactory: CategoryHeaderItem.Factory
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_sponsors,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -1,9 +1,7 @@
 package io.github.droidkaigi.confsched2020.staff.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
@@ -28,7 +26,7 @@ import io.github.droidkaigi.confsched2020.util.ProgressTimeLatch
 import javax.inject.Inject
 import javax.inject.Provider
 
-class StaffsFragment : Fragment() {
+class StaffsFragment : Fragment(R.layout.fragment_staffs) {
 
     @Inject
     lateinit var staffsFactory: Provider<StaffsViewModel>
@@ -44,18 +42,6 @@ class StaffsFragment : Fragment() {
 
     @Inject
     lateinit var staffItemFactory: StaffItem.Factory
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(
-            R.layout.fragment_staffs,
-            container,
-            false
-        )
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)


### PR DESCRIPTION
## Issue
- close #608

## Overview (Required)
- Add [AppInjector](https://github.com/android/architecture-components-samples/blob/e571c59603e8cfb8556af168c29c0c01c829e21c/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt) and replace `DaggerAppCompatActivity` and `DaggerFragment` to it for auto-injection
- Use [Fragment LayoutId constructor](https://developer.android.com/jetpack/androidx/releases/fragment#1.1.0) instead of `onCreateView` because We can now use `androidx.fragment.app.Fragment` as the super class for our Fragments

## Links

## Screenshot

No UI change