### PR TITLE
[iOS] Use barTintColor instead of backgroundColor for UINavigationBar

### DIFF
--- a/ios-base/DroidKaigi 2020/AppDelegate.swift
+++ b/ios-base/DroidKaigi 2020/AppDelegate.swift
@@ -9,12 +9,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if #available(iOS 13, *) {
         } else {
             let window = UIWindow(frame: UIScreen.main.bounds)
-            UINavigationBar.appearance().tintColor = ApplicationScheme.shared.colorScheme.onPrimaryColor
-            UINavigationBar.appearance().backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
+            UINavigationBar.appearance().isTranslucent = false
             let vc = FilterViewController()
             let nvc = NavigationController(rootViewController: vc)
             let root = NavigationDrawerController(rootViewController: nvc, leftViewController: SidebarViewController.instantiate(rootViewController: nvc))
-            nvc.view.backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
             window.rootViewController = root
             self.window = window
             self.window?.makeKeyAndVisible()

--- a/ios-base/DroidKaigi 2020/SceneDelegate.swift
+++ b/ios-base/DroidKaigi 2020/SceneDelegate.swift
@@ -11,13 +11,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
-
-        UINavigationBar.appearance().tintColor = ApplicationScheme.shared.colorScheme.onPrimaryColor
-        UINavigationBar.appearance().backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
+        UINavigationBar.appearance().isTranslucent = false
         let vc = FilterViewController()
         let nvc = NavigationController(rootViewController: vc)
         let root = NavigationDrawerController(rootViewController: nvc, leftViewController: SidebarViewController.instantiate(rootViewController: nvc))
-        nvc.view.backgroundColor = ApplicationScheme.shared.colorScheme.primaryColor
         window.rootViewController = root
         self.window = window
         self.window?.makeKeyAndVisible()

--- a/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
@@ -78,8 +78,8 @@ final class FilterViewController: UIViewController {
                                          action: nil)
         navigationItem.leftBarButtonItems = [menuItem, logoItem]
         navigationItem.rightBarButtonItems = [searchItem]
-        navigationController?.navigationBar
-            .setBackgroundImage(UIImage(), for: .default)
+        navigationController?.navigationBar.barTintColor = ApplicationScheme.shared.colorScheme.primaryColor
+        navigationController?.navigationBar.tintColor = ApplicationScheme.shared.colorScheme.onPrimaryColor
         navigationController?.navigationBar.shadowImage = UIImage()
         edgesForExtendedLayout = []
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Using `barTintColor` is better than `backgroundColor` for `UINavigationBar`.

## Links
- [Swift4でナビゲーションバーの色を変更する](https://qiita.com/k0uhashi/items/0fb4a9e70f4fb11df2f7)
- [UINavigationBarの色がbarTintColorに設定した色よりも薄く表示されてしまう問題](https://qiita.com/haranicle/items/894f8e5aaf182f1e237f)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2077275/73131204-2920e280-404a-11ea-8dcf-81099c4d2ef4.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/2077275/73131207-35a53b00-404a-11ea-97e4-d65c450e81f9.PNG" width="300" />
