### PR TITLE
Fix search auto entered

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.GravityCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
@@ -107,6 +108,8 @@ class MainActivity : DaggerAppCompatActivity() {
             view.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = insets.systemWindowInsetTop + initialState.margins.top
             }
+        }
+        binding.toolbar.doOnLayout {
             // Invalidate because option menu cannot be displayed after screen rotation
             invalidateOptionsMenu()
         }


### PR DESCRIPTION
## Issue
- close #596 

## Overview (Required)
- The cause of this bug is call `invalidateOptionsMenu()` in `toolbar.doOnApplyWindowInsets {}` when query text changed.
- So, changed place of call `invalidateOptionsMenu()` from `toolbar.doOnApplyWindowInsets {}`  to `toolbar.doOnLayout {}`
- We can use `toolbar.doOnNextLayout {}` insted of `toolbar.doOnLayout {}` and resolved too. But, I don't know which is better. 😥

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/18282993/73134381-373a2780-4079-11ea-9a22-8985852fb95a.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/18282993/73134384-402af900-4079-11ea-8748-070c7f62296d.gif" width="300" />
