### PR TITLE
Prevent tapping of the layout under

### DIFF
--- a/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
+++ b/feature/session/src/main/res/layout/fragment_bottom_sheet_sessions.xml
@@ -27,6 +27,8 @@
         android:id="@+id/session"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clickable="true"
+        android:focusable="true"
         tools:context="io.github.droidkaigi.confsched2020.session.ui.SessionPagesFragment"
         >
 


### PR DESCRIPTION
## Issue
close #625

## Overview (Required)
Prevent tapping under layout when tapping fragment_bottom_sheet_sessions.

## Links
None

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/57657221/73151113-276c2300-410d-11ea-96f0-21b731fb70ec.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/57657221/73151158-508cb380-410d-11ea-8498-d36104c49035.gif" width="300" />
