### PR TITLE
Make session's text selectable

### DIFF
--- a/feature/session/src/main/res/layout/item_session_detail_description.xml
+++ b/feature/session/src/main/res/layout/item_session_detail_description.xml
@@ -45,6 +45,7 @@
             android:lineSpacingExtra="8sp"
             android:textAppearance="?textAppearanceBody1"
             android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
             app:layout_constraintTop_toTopOf="parent"

--- a/feature/session/src/main/res/layout/item_session_detail_target.xml
+++ b/feature/session/src/main/res/layout/item_session_detail_target.xml
@@ -73,6 +73,7 @@
             android:text="@{speechSession.intendedAudience}"
             android:textAppearance="@style/TextAppearance.DroidKaigi.Body1"
             android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
             android:lineSpacingExtra="8sp"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toStartOf="@id/guideline_start"

--- a/feature/session/src/main/res/layout/item_session_detail_title.xml
+++ b/feature/session/src/main/res/layout/item_session_detail_title.xml
@@ -76,6 +76,7 @@
             android:text="@{session.timeSummary(lang, TimeZoneOffsetKt.defaultTimeZoneOffset())}"
             android:textAppearance="?textAppearanceCaption"
             android:textColor="?android:attr/textColorPrimary"
+            android:textIsSelectable="true"
             app:layout_constraintBottom_toBottomOf="@id/time_icon"
             app:layout_constraintStart_toEndOf="@id/time_icon"
             app:layout_constraintTop_toTopOf="@id/time_icon"


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- I want to translate session's text from English to Japanese.
  - Make following text selectable in session detail
    - Title
    - Description
    - Target

## Links
- N/A

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/1378923/73226000-eaa63780-41b1-11ea-99fe-2915d917e5e8.jpeg" width="300" />
