### PR TITLE
Update bottom padding for contributor/sponsor/staff fragment

### DIFF
--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.contributor.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -16,6 +17,7 @@ import com.xwray.groupie.databinding.ViewHolder
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.App
 import io.github.droidkaigi.confsched2020.contributor.R
 import io.github.droidkaigi.confsched2020.contributor.databinding.FragmentContributorsBinding
@@ -88,6 +90,17 @@ class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
                     binding.contributor,
                     it,
                     binding.retryButton.visibility != View.VISIBLE
+                )
+            }
+        }
+
+        // Set a bottom padding due to the system UI is enabled.
+        binding.contributorRecycler.run {
+            adapter = groupAdapter
+            doOnApplyWindowInsets { recyclerView, insets, initialState ->
+                // Set a bottom padding due to the system UI is enabled.
+                recyclerView.updatePadding(
+                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
                 )
             }
         }

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -94,7 +94,6 @@ class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
             }
         }
 
-        // Set a bottom padding due to the system UI is enabled.
         binding.contributorRecycler.run {
             adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -50,6 +50,12 @@ class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.contributorRecycler.adapter = groupAdapter
+        binding.contributorRecycler.doOnApplyWindowInsets { recyclerView, insets, initialState ->
+            // Set a bottom padding due to the system UI is enabled.
+            recyclerView.updatePadding(
+                bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+            )
+        }
         // Because custom RecyclerView's animation, set custom SimpleItemAnimator implementation.
         //
         // see https://developer.android.com/reference/androidx/recyclerview/widget/SimpleItemAnimator.html#animateAdd(androidx.recyclerview.widget.RecyclerView.ViewHolder)
@@ -90,15 +96,6 @@ class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
                     binding.contributor,
                     it,
                     binding.retryButton.visibility != View.VISIBLE
-                )
-            }
-        }
-
-        binding.contributorRecycler.run {
-            doOnApplyWindowInsets { recyclerView, insets, initialState ->
-                // Set a bottom padding due to the system UI is enabled.
-                recyclerView.updatePadding(
-                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
                 )
             }
         }

--- a/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
+++ b/feature/contributor/src/main/java/io/github/droidkaigi/confsched2020/contributor/ui/ContributorsFragment.kt
@@ -95,7 +95,6 @@ class ContributorsFragment : Fragment(R.layout.fragment_contributors) {
         }
 
         binding.contributorRecycler.run {
-            adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->
                 // Set a bottom padding due to the system UI is enabled.
                 recyclerView.updatePadding(

--- a/feature/contributor/src/main/res/layout/fragment_contributors.xml
+++ b/feature/contributor/src/main/res/layout/fragment_contributors.xml
@@ -17,6 +17,7 @@
             android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clipToPadding="false"
             android:splitMotionEvents="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:itemCount="10"

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -84,7 +84,6 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
         }
 
         binding.sponsorRecycler.run {
-            adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->
                 // Set a bottom padding due to the system UI is enabled.
                 recyclerView.updatePadding(

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -65,6 +65,12 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
             spanSizeLookup = groupAdapter.spanSizeLookup
         }
         binding.sponsorRecycler.adapter = groupAdapter
+        binding.sponsorRecycler.doOnApplyWindowInsets { recyclerView, insets, initialState ->
+            // Set a bottom padding due to the system UI is enabled.
+            recyclerView.updatePadding(
+                bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+            )
+        }
 
         val progressTimeLatch = ProgressTimeLatch { showProgress ->
             binding.progressBar.isVisible = showProgress
@@ -80,15 +86,6 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
             )
             uiModel.error?.let {
                 systemViewModel.onError(it)
-            }
-        }
-
-        binding.sponsorRecycler.run {
-            doOnApplyWindowInsets { recyclerView, insets, initialState ->
-                // Set a bottom padding due to the system UI is enabled.
-                recyclerView.updatePadding(
-                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
-                )
             }
         }
     }

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -83,7 +83,6 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
             }
         }
 
-        // Set a bottom padding due to the system UI is enabled.
         binding.sponsorRecycler.run {
             adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.sponsor.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -14,6 +15,7 @@ import com.xwray.groupie.Section
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
+import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedActivityViewModels
@@ -78,6 +80,17 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
             )
             uiModel.error?.let {
                 systemViewModel.onError(it)
+            }
+        }
+
+        // Set a bottom padding due to the system UI is enabled.
+        binding.sponsorRecycler.run {
+            adapter = groupAdapter
+            doOnApplyWindowInsets { recyclerView, insets, initialState ->
+                // Set a bottom padding due to the system UI is enabled.
+                recyclerView.updatePadding(
+                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+                )
             }
         }
     }

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -60,6 +60,12 @@ class StaffsFragment : Fragment(R.layout.fragment_staffs) {
 
         val groupAdapter = GroupAdapter<ViewHolder<*>>()
         binding.staffRecycler.adapter = groupAdapter
+        binding.staffRecycler.doOnApplyWindowInsets { recyclerView, insets, initialState ->
+            // Set a bottom padding due to the system UI is enabled.
+            recyclerView.updatePadding(
+                bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+            )
+        }
         // Because custom RecyclerView's animation, set custom SimpleItemAnimator implementation.
         //
         // see https://developer.android.com/reference/androidx/recyclerview/widget/SimpleItemAnimator.html#animateAdd(androidx.recyclerview.widget.RecyclerView.ViewHolder)
@@ -91,15 +97,6 @@ class StaffsFragment : Fragment(R.layout.fragment_staffs) {
 
             uiModel.error?.let {
                 systemViewModel.onError(it)
-            }
-        }
-
-        binding.staffRecycler.run {
-            doOnApplyWindowInsets { recyclerView, insets, initialState ->
-                // Set a bottom padding due to the system UI is enabled.
-                recyclerView.updatePadding(
-                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
-                )
             }
         }
     }

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -94,7 +94,6 @@ class StaffsFragment : Fragment(R.layout.fragment_staffs) {
             }
         }
 
-        // Set a bottom padding due to the system UI is enabled.
         binding.staffRecycler.run {
             adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -95,7 +95,6 @@ class StaffsFragment : Fragment(R.layout.fragment_staffs) {
         }
 
         binding.staffRecycler.run {
-            adapter = groupAdapter
             doOnApplyWindowInsets { recyclerView, insets, initialState ->
                 // Set a bottom padding due to the system UI is enabled.
                 recyclerView.updatePadding(

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2020/staff/ui/StaffsFragment.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.staff.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -15,6 +16,7 @@ import com.xwray.groupie.databinding.ViewHolder
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.App
 import io.github.droidkaigi.confsched2020.di.AppComponent
 import io.github.droidkaigi.confsched2020.di.PageScope
@@ -89,6 +91,17 @@ class StaffsFragment : Fragment(R.layout.fragment_staffs) {
 
             uiModel.error?.let {
                 systemViewModel.onError(it)
+            }
+        }
+
+        // Set a bottom padding due to the system UI is enabled.
+        binding.staffRecycler.run {
+            adapter = groupAdapter
+            doOnApplyWindowInsets { recyclerView, insets, initialState ->
+                // Set a bottom padding due to the system UI is enabled.
+                recyclerView.updatePadding(
+                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+                )
             }
         }
     }

--- a/feature/staff/src/main/res/layout/fragment_staffs.xml
+++ b/feature/staff/src/main/res/layout/fragment_staffs.xml
@@ -16,6 +16,7 @@
             android:id="@+id/staff_recycler"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:clipToPadding="false"
             android:orientation="vertical"
             android:splitMotionEvents="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"


### PR DESCRIPTION
## Issue
None

## Overview (Required)
Add padding to views that overlap the navigation bar when scroll to bottom in RecyclerView.

### Environment
- Pixel3 (Emulator) API 29

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/36199796/73257485-2d462f00-4207-11ea-91e2-17fe0ed775c0.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/36199796/73257479-2cad9880-4207-11ea-81f2-5c22a11c8bc9.gif" width="300" />
<img src="https://user-images.githubusercontent.com/36199796/73257486-2ddec580-4207-11ea-8c69-82358dc91a47.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/36199796/73257482-2d462f00-4207-11ea-8cbf-4e6c7178bc0c.gif" width="300" />
<img src="https://user-images.githubusercontent.com/36199796/73257484-2d462f00-4207-11ea-8220-07087fd3f9ac.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/36199796/73257478-2cad9880-4207-11ea-886f-0705aeb6ce4c.gif" width="300" />
