### PR TITLE
Update Dagger to 2.26

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -310,9 +310,6 @@ abstract class MainActivityModule {
     abstract fun contributeSessionSurveyFragment(): SessionSurveyFragment
 
     @Module
-    companion object
-
-    @Module
     abstract class MainActivityBuilder {
         @ContributesAndroidInjector(modules = [MainActivityModule::class])
         abstract fun contributeMainActivity(): MainActivity

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -126,7 +126,7 @@ object Dep {
     }
 
     object Dagger {
-        val version = "2.25.4"
+        val version = "2.26"
         val core = "com.google.dagger:dagger:$version"
         val compiler = "com.google.dagger:dagger-compiler:$version"
         val androidSupport = "com.google.dagger:dagger-android-support:$version"

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2020/about/ui/AboutFragment.kt
@@ -63,11 +63,9 @@ class AboutFragment : Fragment(R.layout.fragment_about), Injectable {
 @Module
 abstract class AboutFragmentModule {
 
-    @Module
     companion object {
 
         @PageScope
-        @JvmStatic
         @Provides
         fun providesLifecycleOwnerLiveData(
             aboutFragment: AboutFragment

--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2020/announcement/ui/AnnouncementFragment.kt
@@ -101,11 +101,9 @@ class AnnouncementFragment : Fragment(R.layout.fragment_announcement), Injectabl
     @Module
     abstract class AnnouncementFragmentModule {
 
-        @Module
         companion object {
 
             @PageScope
-            @JvmStatic
             @Provides
             fun providesLifecycleOwnerLiveData(
                 announcementFragment: AnnouncementFragment

--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2020/floormap/ui/FloorMapFragment.kt
@@ -15,11 +15,9 @@ class FloorMapFragment : Fragment(R.layout.fragment_floormap), Injectable {
     @Module
     abstract class FloorMapFragmentModule {
 
-        @Module
         companion object {
 
             @PageScope
-            @JvmStatic
             @Provides
             fun providesLifecycleOwnerLiveData(
                 floorMapFragment: FloorMapFragment

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/BottomSheetSessionsFragment.kt
@@ -169,10 +169,8 @@ class BottomSheetSessionsFragment : Fragment(R.layout.fragment_bottom_sheet_sess
 
 @Module
 abstract class BottomSheetSessionsFragmentModule {
-    @Module
     companion object {
         @PageScope
-        @JvmStatic
         @Provides
         fun providesLifecycleOwnerLiveData(
             mainBottomSheetSessionsFragment: BottomSheetSessionsFragment

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/MainSessionsFragment.kt
@@ -131,10 +131,8 @@ abstract class MainSessionsFragmentModule {
     @ContributesAndroidInjector(modules = [SessionsFragmentModule::class])
     abstract fun contributeSessionPageFragment(): SessionsFragment
 
-    @Module
     companion object {
         @PageScope
-        @JvmStatic
         @Provides
         fun providesLifecycleOwnerLiveData(
             mainSessionsFragment: MainSessionsFragment

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SearchSessionsFragment.kt
@@ -196,10 +196,9 @@ class SearchSessionsFragment : Fragment(R.layout.fragment_search_sessions), Inje
 
 @Module
 abstract class SearchSessionsFragmentModule {
-    @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides
+        @Provides
         fun providesLifecycleOwnerLiveData(
             searchSessionsFragment: SearchSessionsFragment
         ): LiveData<LifecycleOwner> {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -236,10 +236,9 @@ class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Inject
 
 @Module
 abstract class SessionDetailFragmentModule {
-    @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides
+        @Provides
         fun providesLifecycleOwnerLiveData(
             sessionDetailFragment: SessionDetailFragment
         ): LiveData<LifecycleOwner> {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -338,10 +338,8 @@ abstract class SessionsFragmentModule {
     )
     abstract fun contributeBottomSheetSessionsFragment(): BottomSheetSessionsFragment
 
-    @Module
     companion object {
         @PageScope
-        @JvmStatic
         @Provides
         fun providesLifecycleOwnerLiveData(
             mainSessionsFragment: MainSessionsFragment

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -77,10 +77,9 @@ class SpeakerFragment : Fragment(R.layout.fragment_speaker), Injectable {
 
 @Module
 abstract class SpeakerFragmentModule {
-    @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides
+        @Provides
         fun providesLifecycleOwnerLiveData(
             speakerFragment: SpeakerFragment
         ): LiveData<LifecycleOwner> {

--- a/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
+++ b/feature/session_survey/src/main/java/io/github/droidkaigi/confsched2020/session_survey/ui/SessionSurveyFragment.kt
@@ -47,11 +47,9 @@ class SessionSurveyFragment : Fragment(R.layout.fragment_session_survey), Inject
 @Module
 abstract class SessionSurveyFragmentModule {
 
-    @Module
     companion object {
 
         @PageScope
-        @JvmStatic
         @Provides
         fun providesLifecycleOwnerLiveData(
             sessionSurveyFragment: SessionSurveyFragment

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/SponsorsFragment.kt
@@ -115,10 +115,9 @@ class SponsorsFragment : Fragment(R.layout.fragment_sponsors), Injectable {
 
 @Module
 abstract class SponsorsFragmentModule {
-    @Module
     companion object {
         @PageScope
-        @JvmStatic @Provides fun providesLifecycleOwnerLiveData(
+        @Provides fun providesLifecycleOwnerLiveData(
             sponsorsFragment: SponsorsFragment
         ): LiveData<LifecycleOwner> {
             return sponsorsFragment.viewLifecycleOwnerLiveData


### PR DESCRIPTION

## Overview (Required)
- Removes unnecessary both `@Module` and `@JvmStatic` from companion objects.


## Links
- https://github.com/google/dagger/releases/tag/dagger-2.26

