### PR TITLE
Update Android Studio to 3.6 RC2

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -3,7 +3,7 @@ package dependencies
 @Suppress("unused")
 object Dep {
     object GradlePlugin {
-        val android = "com.android.tools.build:gradle:3.6.0-rc01"
+        val android = "com.android.tools.build:gradle:3.6.0-rc02"
         val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         val kotlinSerialization = "org.jetbrains.kotlin:kotlin-serialization:${Kotlin.version}"
         val playServices = "com.google.gms:google-services:4.3.3"


### PR DESCRIPTION

## Overview (Required)
- 💪 

## Links
- https://androidstudio.googleblog.com/2020/01/android-studio-36-release-candidate-2.html
