### PR TITLE
Exclude event sessions from day sessions

### DIFF
--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionList.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionList.kt
@@ -2,7 +2,8 @@ package io.github.droidkaigi.confsched2020.model
 
 data class SessionList(private val sessions: List<Session>) : List<Session> by sessions {
     val dayToSessionMap: Map<SessionPage.Day, SessionList> by lazy {
-        groupBy { it.dayNumber }
+        minus(events)
+            .groupBy { it.dayNumber }
             .mapKeys {
                 SessionPage.dayOfNumber(
                     it.key


### PR DESCRIPTION
## Issue
- close #669

## Overview (Required)
- Create day session list after remove event session list.

## Links

nothing

## Screenshot
Before | After
:--: | :--:
![Before_day_1](https://user-images.githubusercontent.com/39234775/73537590-2f5cf780-446c-11ea-9bf9-765a193ba6b7.png) | ![after_day_1](https://user-images.githubusercontent.com/39234775/73537706-70550c00-446c-11ea-8adf-d748a9b00550.png)
![before_event](https://user-images.githubusercontent.com/39234775/73537649-53b8d400-446c-11ea-9c43-b66f05324fbf.png) | ![Screenshot_20200131-201916](https://user-images.githubusercontent.com/39234775/73537724-7d71fb00-446c-11ea-854b-48a6a9701179.png)

