### PR TITLE
Add the entire survey to the navigation drawer

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -65,6 +65,7 @@ import io.github.droidkaigi.confsched2020.sponsor.ui.di.SponsorsAssistedInjectMo
 import io.github.droidkaigi.confsched2020.system.ui.viewmodel.SystemViewModel
 import io.github.droidkaigi.confsched2020.ui.PageConfiguration
 import io.github.droidkaigi.confsched2020.ui.widget.SystemUiManager
+import io.github.droidkaigi.confsched2020.widget.component.NavigationDirections.Companion.actionGlobalToChrome
 import javax.inject.Inject
 import javax.inject.Provider
 import timber.log.Timber
@@ -233,9 +234,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
 
         when (itemId) {
             R.id.entire_survey -> {
-                navController.navigate(R.id.chrome, Bundle().apply {
-                    putString("url", "https://google.com")
-                })
+                navController.navigate(actionGlobalToChrome("https://google.com"))
                 return true
             }
         }

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -231,6 +231,15 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     private fun handleNavigation(@IdRes itemId: Int): Boolean {
         binding.drawerLayout.closeDrawers()
 
+        when (itemId) {
+            R.id.entire_survey -> {
+                navController.navigate(R.id.chrome, Bundle().apply {
+                    putString("url", "https://google.com")
+                })
+                return true
+            }
+        }
+
         return try {
             // ignore if current destination is selected
             if (navController.currentDestination?.id == itemId) return false

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -234,6 +234,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
 
         when (itemId) {
             R.id.entire_survey -> {
+                // TODO: Change to the correct URL
                 navController.navigate(actionGlobalToChrome("https://google.com"))
                 return true
             }

--- a/corecomponent/androidcomponent/src/main/res/drawable/ic_feedback_black_24dp.xml
+++ b/corecomponent/androidcomponent/src/main/res/drawable/ic_feedback_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM13,14h-2v-2h2v2zM13,10h-2L11,6h2v4z"/>
+</vector>

--- a/corecomponent/androidcomponent/src/main/res/menu/menu_nav_drawer.xml
+++ b/corecomponent/androidcomponent/src/main/res/menu/menu_nav_drawer.xml
@@ -50,5 +50,10 @@
             android:icon="@drawable/ic_settings_24px"
             android:title="@string/setting_label"
             />
+        <item
+            android:id="@+id/entire_survey"
+            android:icon="@drawable/ic_feedback_black_24dp"
+            android:title="@string/survey_label"
+            />
     </group>
 </menu>

--- a/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/corecomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -1,8 +1,19 @@
 <navigation
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navigation"
     app:startDestination="@id/main"
     >
+    <action
+        android:id="@+id/action_global_to_chrome"
+        app:destination="@id/chrome">
+        <argument
+            android:name="url"
+            app:argType="string"
+            app:nullable="false"
+            />
+    </action>
+
     <fragment
         android:id="@+id/main"
         android:name="io.github.droidkaigi.confsched2020.session.ui.MainSessionsFragment"


### PR DESCRIPTION
## Issue
- close #652 

## Overview (Required)
- Add the entire survey to the navigation drawer. At this point, go to https://google.com when you press it.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1921209/73553459-57108780-448d-11ea-81ea-7f476fffb166.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1921209/73553361-29c3d980-448d-11ea-8c8c-7b5c11e33efe.png" width="300" />
