### PR TITLE
[suggest]Remove isSameAs instead of Item.id

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -16,7 +16,6 @@ import androidx.core.view.doOnPreDraw
 import androidx.transition.TransitionManager
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.model.Session
@@ -29,7 +28,7 @@ class SessionDetailDescriptionItem @AssistedInject constructor(
     @Assisted private var showEllipsis: Boolean,
     @Assisted private val searchQuery: String?,
     @Assisted private val expandClickListener: () -> Unit
-) : BindableItem<ItemSessionDetailDescriptionBinding>() {
+) : BindableItem<ItemSessionDetailDescriptionBinding>(session.id.hashCode().toLong()) {
 
     companion object {
         private const val ELLIPSIS_LINE_COUNT = 6

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -29,16 +29,13 @@ class SessionDetailDescriptionItem @AssistedInject constructor(
     @Assisted private var showEllipsis: Boolean,
     @Assisted private val searchQuery: String?,
     @Assisted private val expandClickListener: () -> Unit
-) :
-    BindableItem<ItemSessionDetailDescriptionBinding>() {
+) : BindableItem<ItemSessionDetailDescriptionBinding>() {
 
     companion object {
         private const val ELLIPSIS_LINE_COUNT = 6
     }
 
     override fun getLayout() = R.layout.item_session_detail_description
-
-    override fun isSameAs(other: Item<*>): Boolean = other is SessionDetailDescriptionItem
 
     override fun bind(binding: ItemSessionDetailDescriptionBinding, position: Int) {
         val fullDescription = session.desc

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
@@ -15,8 +15,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailM
 class SessionDetailMaterialItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val listener: Listener
-) :
-    BindableItem<ItemSessionDetailMaterialBinding>() {
+) : BindableItem<ItemSessionDetailMaterialBinding>() {
 
     interface Listener {
         fun onClickMovie(movieUrl: String)
@@ -29,8 +28,6 @@ class SessionDetailMaterialItem @AssistedInject constructor(
     override fun bind(binding: ItemSessionDetailMaterialBinding, position: Int) {
         setUpMaterialData(binding)
     }
-
-    override fun isSameAs(other: Item<*>) = other is SessionDetailMaterialItem
 
     private fun setUpMaterialData(binding: ItemSessionDetailMaterialBinding) {
         if (session is SpeechSession) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
@@ -5,7 +5,6 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SpeechSession

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailMaterialItem.kt
@@ -15,7 +15,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailM
 class SessionDetailMaterialItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val listener: Listener
-) : BindableItem<ItemSessionDetailMaterialBinding>() {
+) : BindableItem<ItemSessionDetailMaterialBinding>(session.id.hashCode().toLong()) {
 
     interface Listener {
         fun onClickMovie(movieUrl: String)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
@@ -1,13 +1,12 @@
 package io.github.droidkaigi.confsched2020.session.ui.item
 
 import com.squareup.inject.assisted.AssistedInject
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.session.R
 import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailSpeakerSubtitleBinding
 
 class SessionDetailSpeakerSubtitleItem @AssistedInject constructor() :
-    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>() {
+    BindableItem<ItemSessionDetailSpeakerSubtitleBinding>(GROUPIE_ITEM_ID) {
     override fun getLayout() = R.layout.item_session_detail_speaker_subtitle
 
     override fun bind(binding: ItemSessionDetailSpeakerSubtitleBinding, position: Int) {
@@ -16,5 +15,9 @@ class SessionDetailSpeakerSubtitleItem @AssistedInject constructor() :
     @AssistedInject.Factory
     interface Factory {
         fun create(): SessionDetailSpeakerSubtitleItem
+    }
+
+    companion object {
+        private const val GROUPIE_ITEM_ID = -1L
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailSpeakerSubtitleItem.kt
@@ -13,8 +13,6 @@ class SessionDetailSpeakerSubtitleItem @AssistedInject constructor() :
     override fun bind(binding: ItemSessionDetailSpeakerSubtitleBinding, position: Int) {
     }
 
-    override fun isSameAs(other: Item<*>) = other is SessionDetailSpeakerSubtitleItem
-
     @AssistedInject.Factory
     interface Factory {
         fun create(): SessionDetailSpeakerSubtitleItem

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
@@ -22,8 +22,6 @@ class SessionDetailTargetItem @AssistedInject constructor(
         binding.speechSession = (session as? SpeechSession)
     }
 
-    override fun isSameAs(other: Item<*>) = other is SessionDetailTargetItem
-
     @AssistedInject.Factory
     interface Factory {
         fun create(session: Session): SessionDetailTargetItem

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTargetItem.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.confsched2020.session.ui.item
 
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SpeechSession
@@ -14,7 +13,7 @@ import io.github.droidkaigi.confsched2020.session.databinding.ItemSessionDetailT
  */
 class SessionDetailTargetItem @AssistedInject constructor(
     @Assisted private val session: Session
-) : BindableItem<ItemSessionDetailTargetBinding>() {
+) : BindableItem<ItemSessionDetailTargetBinding>(session.id.hashCode().toLong()) {
     override fun getLayout() = R.layout.item_session_detail_target
 
     override fun bind(binding: ItemSessionDetailTargetBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
@@ -9,7 +9,6 @@ import androidx.core.view.isVisible
 import com.google.android.material.chip.Chip
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.ext.getThemeColor
 import io.github.droidkaigi.confsched2020.model.Session
@@ -22,7 +21,7 @@ import java.util.regex.Pattern
 class SessionDetailTitleItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val searchQuery: String?
-) : BindableItem<ItemSessionDetailTitleBinding>() {
+) : BindableItem<ItemSessionDetailTitleBinding>(session.id.hashCode().toLong()) {
     override fun getLayout() = R.layout.item_session_detail_title
 
     override fun bind(binding: ItemSessionDetailTitleBinding, position: Int) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailTitleItem.kt
@@ -22,8 +22,7 @@ import java.util.regex.Pattern
 class SessionDetailTitleItem @AssistedInject constructor(
     @Assisted private val session: Session,
     @Assisted private val searchQuery: String?
-) :
-    BindableItem<ItemSessionDetailTitleBinding>() {
+) : BindableItem<ItemSessionDetailTitleBinding>() {
     override fun getLayout() = R.layout.item_session_detail_title
 
     override fun bind(binding: ItemSessionDetailTitleBinding, position: Int) {
@@ -61,8 +60,6 @@ class SessionDetailTitleItem @AssistedInject constructor(
 //            binding.sessionMessage.isVisible = true
         }
     }
-
-    override fun isSameAs(other: Item<*>) = other is SessionDetailTitleItem
 
     private fun TextView.setSearchHighlight() {
         doOnPreDraw {

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/DividerItem.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2020/sponsor/ui/item/DividerItem.kt
@@ -1,17 +1,16 @@
 package io.github.droidkaigi.confsched2020.sponsor.ui.item
 
-import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2020.sponsor.R
 import io.github.droidkaigi.confsched2020.sponsor.databinding.ItemDividerBinding
 
-class DividerItem : BindableItem<ItemDividerBinding>() {
+class DividerItem : BindableItem<ItemDividerBinding>(GROUPIE_ITEM_ID) {
     override fun getLayout(): Int = R.layout.item_divider
 
     override fun bind(viewBinding: ItemDividerBinding, position: Int) {
     }
 
-    override fun isSameAs(other: Item<*>): Boolean {
-        return other is DividerItem
+    companion object {
+        private const val GROUPIE_ITEM_ID = -1L
     }
 }


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
`com.xwray.groupie.Item.isSameAs` is this code.

```
    /**
     * Whether two item objects represent the same underlying data when compared using DiffUtil,
     * even if there has been a change in that data.
     * <p>
     * The default implementation compares both view type and id.
     */
    public boolean isSameAs(Item other) {
        if (getLayout() != other.getLayout()) {
            return false;
        }
        return getId() == other.getId();
    }
```

`getLayout() != other.getLayout()` result is same as `other is HogeItem` result.
So I delete that methods.

And, `getId()` is following.

```
    private static AtomicLong ID_COUNTER = new AtomicLong(0);
    private final long id;

    public Item() {
        this(ID_COUNTER.decrementAndGet());
    }

    protected Item(long id) {
        this.id = id;
    }

    /**
     * If you don't specify an id, this id is an auto-generated unique negative integer for each Item (the less
     * likely to conflict with your model IDs.)
     * <p>
     * You may prefer to override it with the ID of a model object, for example the primary key of
     * an object from a database that it represents.
     *
     * @return A unique id
     */
    public long getId() {
        return id;
    }
```

Therefore, I add unique id.
(If we don't use a same layout, we don't request the uniqueness.)

## Links
- [Item.java](https://github.com/lisawray/groupie/blob/master/library/src/main/java/com/xwray/groupie/Item.java)

## Screenshot
