### PR TITLE
Home button is difficult to see in dark Theme.

### DIFF
--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/MainActivity.kt
@@ -226,6 +226,9 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
         statusBarColors.statusBarColor.distinctUntilChanged().observe(this) { color ->
             window.statusBarColor = color
         }
+        statusBarColors.navigationBarColor.distinctUntilChanged().observe(this) { color ->
+            window.navigationBarColor = color
+        }
     }
 
     private fun handleNavigation(@IdRes itemId: Int): Boolean {

--- a/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/widget/SystemUiManager.kt
+++ b/android-base/src/main/java/io/github/droidkaigi/confsched2020/ui/widget/SystemUiManager.kt
@@ -19,6 +19,10 @@ class SystemUiManager(
         MutableLiveData(COLOR_STATUS_BAR_INVISIBLE)
     val statusBarColor: LiveData<Int> = _statusBarColor
 
+    private val _navigationBarColor =
+        MutableLiveData(COLOR_NAVIGATION_BAR_INVISIBLE)
+    val navigationBarColor: LiveData<Int> = _navigationBarColor
+
     var drawerSlideOffset: Float = 0f
         set(value) {
             if (field != value) {
@@ -70,6 +74,18 @@ class SystemUiManager(
             } else {
                 COLOR_STATUS_BAR_INVISIBLE
             }
+
+        // Navigation bar color
+        _navigationBarColor.value =
+            if (context.isNightMode()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    COLOR_NAVIGATION_BAR_INVISIBLE
+                } else {
+                    COLOR_NAVIGATION_BAR_VISIBLE
+                }
+            } else {
+                COLOR_NAVIGATION_BAR_INVISIBLE
+            }
     }
 
     private fun updateColorsPreM() {
@@ -90,10 +106,24 @@ class SystemUiManager(
             } else {
                 COLOR_STATUS_BAR_INVISIBLE
             }
+
+        // Navigation bar color
+        _navigationBarColor.value =
+            if (context.isNightMode()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    COLOR_NAVIGATION_BAR_INVISIBLE
+                } else {
+                    COLOR_NAVIGATION_BAR_VISIBLE
+                }
+            } else {
+                COLOR_NAVIGATION_BAR_INVISIBLE
+            }
     }
 
     companion object {
         private const val COLOR_STATUS_BAR_INVISIBLE = Color.TRANSPARENT
         private const val COLOR_STATUS_BAR_VISIBLE = 0x8a000000.toInt()
+        private const val COLOR_NAVIGATION_BAR_INVISIBLE = Color.TRANSPARENT
+        private const val COLOR_NAVIGATION_BAR_VISIBLE = 0x4DFFFFFF
     }
 }


### PR DESCRIPTION
## Issue
- close #498

## Overview (Required)
- When using a dark theme on Android9 or lower, set NavigationBar to a color with low transparency.

- Prepare LiveData in SystemUiManager in a form similar to the status bar, and change the color of the navigation bar according to the OS version when Context.isNightMode changes.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/726084/73592183-df009b00-453a-11ea-9790-e428fd405fdd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/726084/73592170-c7c1ad80-453a-11ea-8969-66d5a23102de.png" width="300" />

