### PR TITLE
`make init` failed on using shell installed by Homebrew

### DIFF
--- a/ios-base/scripts/bootstrap.sh
+++ b/ios-base/scripts/bootstrap.sh
@@ -3,9 +3,9 @@
 GIT_REPO=$(git rev-parse --show-toplevel)
 GIT_DIR=$(git rev-parse --git-dir)
 
-if [ "$SHELL" = '/bin/bash' ]; then
+if [ "$SHELL" = '/bin/bash' ] || [ "$SHELL" = '/usr/local/bin/bash' ]; then
     SHELL_RESOURCE=~/.bashrc
-elif [ "$SHELL" = '/bin/zsh' ]; then
+elif [ "$SHELL" = '/bin/zsh' ] || [ "$SHELL" = '/usr/local/bin/zsh' ]; then
     SHELL_RESOURCE=~/.zshrc
 else
     echo "Unsupported shell: ${SHELL}"


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- `make init` is failed on using shell that installed by `Homebrew`.
```shell
> make init
Unsupported shell: /usr/local/bin/zsh
make: *** [init] Error 1
```

## Links
-

## Screenshot
