### PR TITLE
[iOS] Add blank event tab

### DIFF
--- a/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
@@ -11,19 +11,6 @@ class EventViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
@@ -1,0 +1,29 @@
+//
+//  EventViewController.swift
+//  DroidKaigi 2020
+//
+//  Created by Hidenari Tajima on 2020/02/02.
+//
+
+import UIKit
+
+class EventViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/EventViewController.swift
@@ -1,16 +1,7 @@
-//
-//  EventViewController.swift
-//  DroidKaigi 2020
-//
-//  Created by Hidenari Tajima on 2020/02/02.
-//
-
 import UIKit
 
 class EventViewController: UIViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-
 }

--- a/ios-base/DroidKaigi 2020/Session/Views/EventViewController.xib
+++ b/ios-base/DroidKaigi 2020/Session/Views/EventViewController.xib
@@ -1,22 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EventViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EventViewController" customModule="DroidKaigi_2020" customModuleProvider="target">
             <connections>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ここにイベントが表示される" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d6G-AO-XOG">
+                    <rect key="frame" x="94" y="438" width="226" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="d6G-AO-XOG" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="J4a-Yd-qLF"/>
+                <constraint firstItem="d6G-AO-XOG" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="mVY-3y-5qk"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="275" y="84"/>
         </view>
     </objects>
 </document>

--- a/ios-base/DroidKaigi 2020/Session/Views/EventViewController.xib
+++ b/ios-base/DroidKaigi 2020/Session/Views/EventViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EventViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/FilterViewController.swift
@@ -100,7 +100,8 @@ final class FilterViewController: UIViewController {
         tabBar.items = [
             UITabBarItem(title: "DAY1", image: nil, tag: 0),
             UITabBarItem(title: "DAY2", image: nil, tag: 1),
-            UITabBarItem(title: "MYPLAN", image: nil, tag: 2),
+            UITabBarItem(title: "EVENT", image: nil, tag: 2),
+            UITabBarItem(title: "MYPLAN", image: nil, tag: 3),
         ]
         tabBar.alignment = .justified
         tabBar.itemAppearance = .titles
@@ -222,6 +223,8 @@ extension FilterViewController: MDCTabBarDelegate {
         case 1:
             embeddedViewController?.setViewControllers(type: .day2)
         case 2:
+            embeddedViewController?.setViewControllers(type: .event)
+        case 3:
             embeddedViewController?.setViewControllers(type: .myPlan)
         default:
             break

--- a/ios-base/DroidKaigi 2020/Session/Views/SessionPageViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/SessionPageViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 enum SessionViewControllerType: Int {
     case day1 = 1
     case day2 = 2
-    case myPlan = 3
+    case event = 3
+    case myPlan = 4
 
     var date: Date? {
         let calendar = Calendar(identifier: .gregorian)
@@ -12,6 +13,8 @@ enum SessionViewControllerType: Int {
             return calendar.date(from: .init(year: 2020, month: 2, day: 20))
         case .day2:
             return calendar.date(from: .init(year: 2020, month: 2, day: 21))
+        case .event:
+            return nil
         case .myPlan:
             return nil
         }
@@ -45,6 +48,7 @@ final class SessionPageViewController: UIPageViewController {
         sessionViewControllers = [
             SessionViewController(viewModel: viewModel, sessionViewType: .day1),
             SessionViewController(viewModel: viewModel, sessionViewType: .day2),
+            EventViewController(),
             SessionViewController(viewModel: viewModel, sessionViewType: .myPlan),
         ]
         setViewControllers([sessionViewControllers[0]], direction: .forward, animated: true)
@@ -76,6 +80,9 @@ extension SessionPageViewController: UIPageViewControllerDataSource {
         case sessionViewControllers[2]:
             selectedViewControllerIndex = 1
             return sessionViewControllers[1]
+        case sessionViewControllers[3]:
+            selectedViewControllerIndex = 2
+            return sessionViewControllers[2]
         default:
             return nil
         }
@@ -90,6 +97,9 @@ extension SessionPageViewController: UIPageViewControllerDataSource {
             selectedViewControllerIndex = 2
             return sessionViewControllers[2]
         case sessionViewControllers[2]:
+            selectedViewControllerIndex = 3
+            return sessionViewControllers[3]
+        case sessionViewControllers[3]:
             return nil
         default:
             return nil


### PR DESCRIPTION
## Issue
- #657 

## Overview (Required)
- Add a blank event tab for the iOS app.
- I created a new SessionViewControllerType .event and adjust the raw number carefully.
- I created a new EventViewController because it's not Session and it doesn't have a filtering view.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6965122/73604582-5e8f7800-45d6-11ea-834a-52e06e50a82c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6965122/73604564-225c1780-45d6-11ea-88d6-87b2b97b21e9.png" width="300" />