### PR TITLE
Fixed that long speaker description will not scroll up from under the navigation bar

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.session.ui
 import android.os.Bundle
 import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -14,6 +15,7 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.GroupieViewHolder
 import dagger.Module
 import dagger.Provides
+import dev.chrisbanes.insetter.doOnApplyWindowInsets
 import io.github.droidkaigi.confsched2020.di.Injectable
 import io.github.droidkaigi.confsched2020.di.PageScope
 import io.github.droidkaigi.confsched2020.ext.assistedViewModels
@@ -53,7 +55,12 @@ class SpeakerFragment : Fragment(R.layout.fragment_speaker), Injectable {
         binding.progressBar.show()
 
         val groupAdapter = GroupAdapter<GroupieViewHolder<*>>()
-        binding.speakerRecycler.adapter = groupAdapter
+        binding.speakerRecycler.also {
+            it.adapter = groupAdapter
+            it.doOnApplyWindowInsets { recyclerView, insets, initialState ->
+                recyclerView.updatePadding(bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom)
+            }
+        }
 
         speakerViewModel.uiModel.distinctUntilChanged()
             .observe(viewLifecycleOwner) { uiModel: SpeakerViewModel.UiModel ->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SpeakerFragment.kt
@@ -58,7 +58,9 @@ class SpeakerFragment : Fragment(R.layout.fragment_speaker), Injectable {
         binding.speakerRecycler.also {
             it.adapter = groupAdapter
             it.doOnApplyWindowInsets { recyclerView, insets, initialState ->
-                recyclerView.updatePadding(bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom)
+                recyclerView.updatePadding(
+                    bottom = insets.systemWindowInsetBottom + initialState.paddings.bottom
+                )
             }
         }
 

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -15,6 +15,7 @@
             android:id="@+id/speaker_recycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clipToPadding="false"
             android:splitMotionEvents="false"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:itemCount="1"


### PR DESCRIPTION
## Overview (Required)
-  Fixed that long speaker description will not scroll up from under the navigation bar

1. Go to Speaker Detail which has long description.
2. Scroll the page to the bottom

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7691979/73608298-a9c07f80-4604-11ea-873d-5a821660084a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7691979/73608304-b6dd6e80-4604-11ea-93cc-b3184531afee.png" width="300" />
