### PR TITLE
Adjust line spacing of the description in about page

### DIFF
--- a/feature/about/src/main/res/layout/item_about_header.xml
+++ b/feature/about/src/main/res/layout/item_about_header.xml
@@ -42,6 +42,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="32dp"
+            android:lineSpacingExtra="8sp"
             android:text="@string/about_description"
             android:textAppearance="?textAppearanceBody1"
             android:textSize="16sp"


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Set `lineSpacingExtra` to `8sp` like other multi-line text components for readability.

## Screenshot

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7891554/73609680-8ea93c00-4613-11ea-9358-afe186023f02.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7891554/73609671-7f29f300-4613-11ea-9e6b-c27f2fe2eca4.png" width="300" />
