### PR TITLE
Fix level filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,13 +58,13 @@ jobs:
       - run: .circleci/android/deploy-to-deploygate.bash
       - restore_and_save_bundler_cache
       - run: .circleci/android/try-it.bash
-  
+
   test_android:
     executor: android
     steps:
       - checkout
       - restore_and_save_gradle_cache
-      - run: ./gradlew lintDebug testDebugUnitTest ktlint --continue --offline || true
+      - run: ./gradlew lintDebug testDebugUnitTest jvmTest ktlint --continue --offline || true
       - run: .ci/scripts/collect-test-artifacts.bash
       - run: .ci/scripts/collect-ktlint-artifacts.bash
       - store_test_results:

--- a/.github/workflows/on_release_branch.yml
+++ b/.github/workflows/on_release_branch.yml
@@ -147,7 +147,7 @@ jobs:
           ${{ runner.os }}-m2-${{ hashFiles('buildSrc/**/*.kt') }}-${{ hashFiles('**/*.gradle.kts') }}-
           ${{ runner.os }}-m2-${{ hashFiles('buildSrc/**/*.kt') }}-
           ${{ runner.os }}-m2-
-    - run: ./gradlew lintRelease testRelease ktlint --continue
+    - run: ./gradlew lintRelease testRelease jvmTest ktlint --continue
       shell: bash
     - name: Collect test artifacts
       if: always()

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/response/SessionResponseImpl.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/response/SessionResponseImpl.kt
@@ -21,5 +21,6 @@ internal data class SessionResponseImpl(
     override val targetAudience: String,
     override val interpretationTarget: Boolean,
     override val videoUrl: String? = null,
-    override val slideUrl: String? = null
+    override val slideUrl: String? = null,
+    override val levels: List<String>
 ) : SessionResponse

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/response/SessionResponse.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/response/SessionResponse.kt
@@ -18,4 +18,5 @@ interface SessionResponse {
     val videoUrl: String?
     val slideUrl: String?
     val interpretationTarget: Boolean
+    val levels: List<String>
 }

--- a/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/db/entity/LevelEntity.kt
+++ b/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/db/entity/LevelEntity.kt
@@ -1,0 +1,7 @@
+package io.github.droidkaigi.confsched2020.data.db.entity
+
+interface LevelEntity {
+    val isBeginner: Boolean
+    val isIntermediate: Boolean
+    val isAdvanced: Boolean
+}

--- a/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/db/entity/SessionEntity.kt
+++ b/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/db/entity/SessionEntity.kt
@@ -17,4 +17,5 @@ interface SessionEntity {
     val message: MessageEntity?
     val isServiceSession: Boolean
     val sessionType: String?
+    val level: LevelEntity
 }

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/CacheDatabase.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/CacheDatabase.kt
@@ -28,7 +28,7 @@ import io.github.droidkaigi.confsched2020.data.db.internal.entity.StaffEntityImp
         (StaffEntityImpl::class),
         (ContributorEntityImpl::class)
     ],
-    version = 17
+    version = 18
 )
 internal abstract class CacheDatabase : RoomDatabase() {
     abstract fun sessionDao(): SessionDao

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/LevelEntityImpl.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/LevelEntityImpl.kt
@@ -1,0 +1,13 @@
+package io.github.droidkaigi.confsched2020.data.db.internal.entity
+
+import androidx.room.ColumnInfo
+import io.github.droidkaigi.confsched2020.data.db.entity.LevelEntity
+
+internal data class LevelEntityImpl (
+    @ColumnInfo(name = "is_beginner")
+    override val isBeginner: Boolean,
+    @ColumnInfo(name = "is_intermediate")
+    override val isIntermediate: Boolean,
+    @ColumnInfo(name = "is_advanced")
+    override val isAdvanced: Boolean
+) : LevelEntity

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/LevelEntityImpl.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/LevelEntityImpl.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2020.data.db.internal.entity
 import androidx.room.ColumnInfo
 import io.github.droidkaigi.confsched2020.data.db.entity.LevelEntity
 
-internal data class LevelEntityImpl (
+internal data class LevelEntityImpl(
     @ColumnInfo(name = "is_beginner")
     override val isBeginner: Boolean,
     @ColumnInfo(name = "is_intermediate")

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/SessionEntityImpl.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/SessionEntityImpl.kt
@@ -22,5 +22,6 @@ internal data class SessionEntityImpl(
     override var language: String,
     @Embedded override val category: CategoryEntityImpl?,
     @Embedded override val room: RoomEntityImpl?,
-    @Embedded override val message: MessageEntityImpl?
+    @Embedded override val message: MessageEntityImpl?,
+    @Embedded override val level: LevelEntityImpl
 ) : SessionEntity

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
@@ -5,8 +5,8 @@ import io.github.droidkaigi.confsched2020.model.Level
 
 internal fun List<String>.toLevelEntity(): LevelEntityImpl {
     return LevelEntityImpl(
-        isBeginner = contains(Level.BEGINNER.name),
-        isIntermediate = contains(Level.INTERMEDIATE.name),
-        isAdvanced = contains(Level.ADVANCED.name)
+        isBeginner = contains(Level.BEGINNER.id),
+        isIntermediate = contains(Level.INTERMEDIATE.id),
+        isAdvanced = contains(Level.ADVANCED.id)
     )
 }

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2020.data.db.internal.entity.mapper
 
-import io.github.droidkaigi.confsched2020.data.db.entity.LevelEntity
 import io.github.droidkaigi.confsched2020.data.db.internal.entity.LevelEntityImpl
 import io.github.droidkaigi.confsched2020.model.Level
 

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/LevelDataMapperExt.kt
@@ -1,0 +1,13 @@
+package io.github.droidkaigi.confsched2020.data.db.internal.entity.mapper
+
+import io.github.droidkaigi.confsched2020.data.db.entity.LevelEntity
+import io.github.droidkaigi.confsched2020.data.db.internal.entity.LevelEntityImpl
+import io.github.droidkaigi.confsched2020.model.Level
+
+internal fun List<String>.toLevelEntity(): LevelEntityImpl {
+    return LevelEntityImpl(
+        isBeginner = contains(Level.BEGINNER.name),
+        isIntermediate = contains(Level.INTERMEDIATE.name),
+        isAdvanced = contains(Level.ADVANCED.name)
+    )
+}

--- a/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/SessionDataMapperExt.kt
+++ b/data/db/src/main/java/io/github/droidkaigi/confsched2020/data/db/internal/entity/mapper/SessionDataMapperExt.kt
@@ -73,7 +73,8 @@ internal fun SessionResponse.toSessionEntityImpl(
                 requireNotNull(room.name?.en),
                 requireNotNull(room.sort)
             ),
-            sessionType = sessionType
+            sessionType = sessionType,
+            level = levels.toLevelEntity()
         )
     } else {
         return SessionEntityImpl(
@@ -99,7 +100,8 @@ internal fun SessionResponse.toSessionEntityImpl(
             message = message?.let {
                 MessageEntityImpl(requireNotNull(it.ja), requireNotNull(it.en))
             },
-            sessionType = sessionType
+            sessionType = sessionType,
+            level = levels.toLevelEntity()
         )
     }
 }

--- a/data/repository/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/repository/ResponseToModelMapper.kt
+++ b/data/repository/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/repository/ResponseToModelMapper.kt
@@ -9,10 +9,10 @@ import io.github.droidkaigi.confsched2020.data.api.response.Response
 import io.github.droidkaigi.confsched2020.data.api.response.RoomResponse
 import io.github.droidkaigi.confsched2020.data.api.response.SessionResponse
 import io.github.droidkaigi.confsched2020.data.api.response.SpeakerResponse
-import io.github.droidkaigi.confsched2020.model.AudienceCategory
 import io.github.droidkaigi.confsched2020.model.Category
 import io.github.droidkaigi.confsched2020.model.Lang
 import io.github.droidkaigi.confsched2020.model.LangSupport
+import io.github.droidkaigi.confsched2020.model.Level
 import io.github.droidkaigi.confsched2020.model.LocaledString
 import io.github.droidkaigi.confsched2020.model.Room
 import io.github.droidkaigi.confsched2020.model.ServiceSession
@@ -47,7 +47,7 @@ fun Response.toModel(): SessionContents {
         langSupports = LangSupport.values().toList(),
         rooms = sessions.map { it.room }.sortedBy { it.sort }.distinct(),
         category = speechSessions.map { it.category }.distinct(),
-        audienceCategories = AudienceCategory.values().toList()
+        levels = Level.values().toList()
     )
 }
 
@@ -111,7 +111,8 @@ private fun SessionResponse.toSession(
                     requireNotNull(it.ja),
                     requireNotNull(it.en)
                 )
-            }
+            },
+            levels = response.levels.map { Level.findLevel(it) }
         )
     } else {
         ServiceSession(
@@ -133,7 +134,8 @@ private fun SessionResponse.toSession(
             ),
             // TODO
             isFavorited = false,
-            sessionType = SessionType.of(response.sessionType)
+            sessionType = SessionType.of(response.sessionType),
+            levels = response.levels.map { Level.findLevel(it) }
         )
     }
 }

--- a/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/DataSessionRepository.kt
+++ b/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/DataSessionRepository.kt
@@ -8,9 +8,9 @@ import io.github.droidkaigi.confsched2020.data.firestore.Firestore
 import io.github.droidkaigi.confsched2020.data.repository.internal.mapper.toSession
 import io.github.droidkaigi.confsched2020.data.repository.internal.mapper.toSessionFeedback
 import io.github.droidkaigi.confsched2020.data.repository.internal.workmanager.FavoriteToggleWork
-import io.github.droidkaigi.confsched2020.model.AudienceCategory
 import io.github.droidkaigi.confsched2020.model.Lang
 import io.github.droidkaigi.confsched2020.model.LangSupport
+import io.github.droidkaigi.confsched2020.model.Level
 import io.github.droidkaigi.confsched2020.model.Session
 import io.github.droidkaigi.confsched2020.model.SessionContents
 import io.github.droidkaigi.confsched2020.model.SessionFeedback
@@ -49,7 +49,7 @@ internal class DataSessionRepository @Inject constructor(
                 langSupports = LangSupport.values().toList(),
                 rooms = sessions.map { it.room }.sortedBy { it.sort }.distinct(),
                 category = speechSessions.map { it.category }.distinct(),
-                audienceCategories = AudienceCategory.values().toList()
+                levels = Level.values().toList()
             )
         }
     }

--- a/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/mapper/LevelMapper.kt
+++ b/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/mapper/LevelMapper.kt
@@ -1,0 +1,10 @@
+package io.github.droidkaigi.confsched2020.data.repository.internal.mapper
+
+import io.github.droidkaigi.confsched2020.data.db.entity.LevelEntity
+import io.github.droidkaigi.confsched2020.model.Level
+
+fun LevelEntity.toLevels(): List<Level> {
+    val entityValues = listOf(isBeginner, isIntermediate, isAdvanced)
+    val modelValues = Level.values()
+    return entityValues.zip(modelValues).filter { it.first }.map { it.second }
+}

--- a/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/mapper/SessionMappers.kt
+++ b/data/repository/src/main/java/io/github/droidkaigi/confsched2020/data/repository/internal/mapper/SessionMappers.kt
@@ -41,7 +41,8 @@ fun SessionWithSpeakers.toSession(
                 Room(room.id, LocaledString(room.name, room.enName), room.sort)
             },
             sessionType = SessionType.of(session.sessionType),
-            isFavorited = favList!!.contains(session.id)
+            isFavorited = favList!!.contains(session.id),
+            levels = session.level.toLevels()
         )
     } else {
         require(speakerIdList.isNotEmpty())
@@ -81,7 +82,8 @@ fun SessionWithSpeakers.toSession(
             speakers = speakers,
             message = session.message?.let {
                 LocaledString(it.ja, it.en)
-            }
+            },
+            levels = session.level.toLevels()
         )
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -178,11 +178,11 @@ class SessionsFragment : Fragment(R.layout.fragment_sessions), HasAndroidInjecto
                 sessionsViewModel.filterChanged(category, checked)
             }
             binding.audienceCategoryFilters.setupFilter(
-                allFilterSet = uiModel.allFilters.audienceCategories,
-                currentFilterSet = uiModel.filters.audienceCategories,
+                allFilterSet = uiModel.allFilters.levels,
+                currentFilterSet = uiModel.filters.levels,
                 filterName = { it.name }
-            ) { checked, audienceCategory ->
-                sessionsViewModel.filterChanged(audienceCategory, checked)
+            ) { checked, level ->
+                sessionsViewModel.filterChanged(level, checked)
             }
             binding.languageSupportFilters.setupFilter(
                 allFilterSet = uiModel.allFilters.langSupports,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionsFragment.kt
@@ -177,10 +177,10 @@ class SessionsFragment : Fragment(R.layout.fragment_sessions), HasAndroidInjecto
             ) { checked, category ->
                 sessionsViewModel.filterChanged(category, checked)
             }
-            binding.audienceCategoryFilters.setupFilter(
+            binding.levelFilters.setupFilter(
                 allFilterSet = uiModel.allFilters.levels,
                 currentFilterSet = uiModel.filters.levels,
-                filterName = { it.name }
+                filterName = { it.rawValue.getByLang(defaultLang()) }
             ) { checked, level ->
                 sessionsViewModel.filterChanged(level, checked)
             }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModel.kt
@@ -11,11 +11,11 @@ import io.github.droidkaigi.confsched2020.ext.requireValue
 import io.github.droidkaigi.confsched2020.ext.toAppError
 import io.github.droidkaigi.confsched2020.ext.toLoadingState
 import io.github.droidkaigi.confsched2020.model.AppError
-import io.github.droidkaigi.confsched2020.model.AudienceCategory
 import io.github.droidkaigi.confsched2020.model.Category
 import io.github.droidkaigi.confsched2020.model.Filters
 import io.github.droidkaigi.confsched2020.model.Lang
 import io.github.droidkaigi.confsched2020.model.LangSupport
+import io.github.droidkaigi.confsched2020.model.Level
 import io.github.droidkaigi.confsched2020.model.LoadState
 import io.github.droidkaigi.confsched2020.model.LoadingState
 import io.github.droidkaigi.confsched2020.model.Room
@@ -116,7 +116,7 @@ class SessionsViewModel @Inject constructor(
             filters = filters,
             allFilters = Filters(
                 rooms = sessionContents.rooms.toSet(),
-                audienceCategories = sessionContents.audienceCategories.toSet(),
+                levels = sessionContents.levels.toSet(),
                 categories = sessionContents.category.toSet(),
                 langs = sessionContents.langs.toSet(),
                 langSupports = sessionContents.langSupports.toSet()
@@ -178,13 +178,13 @@ class SessionsViewModel @Inject constructor(
         )
     }
 
-    fun filterChanged(audienceCategory: AudienceCategory, checked: Boolean) {
+    fun filterChanged(level: Level, checked: Boolean) {
         val filters = filterLiveData.requireValue()
         filterLiveData.value = filters.copy(
-            audienceCategories = if (checked) {
-                filters.audienceCategories + audienceCategory
+            levels = if (checked) {
+                filters.levels + level
             } else {
-                filters.audienceCategories - audienceCategory
+                filters.levels - level
             }
         )
     }

--- a/feature/session/src/main/res/layout/fragment_sessions.xml
+++ b/feature/session/src/main/res/layout/fragment_sessions.xml
@@ -122,11 +122,11 @@
                         />
 
                     <TextView
-                        android:id="@+id/filter_audience_category_title"
+                        android:id="@+id/filter_level_title"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="32dp"
-                        android:text="@string/filter_audience_category"
+                        android:text="@string/filter_level"
                         android:textAppearance="@style/TextAppearance.DroidKaigi.Subtitle2"
                         android:textColor="?attr/colorOnPrimary"
                         app:layout_constraintStart_toStartOf="@id/guideline_start"
@@ -134,7 +134,7 @@
                         />
 
                     <com.google.android.material.chip.ChipGroup
-                        android:id="@+id/audience_category_filters"
+                        android:id="@+id/level_filters"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="8dp"
@@ -142,7 +142,7 @@
                         app:layout_constraintEnd_toEndOf="@id/guideline_end"
                         app:layout_constraintHorizontal_bias="0.0"
                         app:layout_constraintStart_toStartOf="@id/guideline_start"
-                        app:layout_constraintTop_toBottomOf="@id/filter_audience_category_title"
+                        app:layout_constraintTop_toBottomOf="@id/filter_level_title"
                         />
 
                     <TextView
@@ -154,7 +154,7 @@
                         android:textAppearance="@style/TextAppearance.DroidKaigi.Subtitle2"
                         android:textColor="?attr/colorOnPrimary"
                         app:layout_constraintStart_toStartOf="@id/guideline_start"
-                        app:layout_constraintTop_toBottomOf="@id/audience_category_filters"
+                        app:layout_constraintTop_toBottomOf="@id/level_filters"
                         />
 
                     <com.google.android.material.chip.ChipGroup

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="filter_reset">Reset</string>
     <string name="filter_room" translatable="false">Room</string>
     <string name="filter_language" translatable="false">Language</string>
-    <string name="filter_audience_category" translatable="false">Level</string>
+    <string name="filter_level" translatable="false">Level</string>
     <string name="filter_category" translatable="false">Category</string>
     <string name="filter_language_support" translatable="false">Language Support</string>
     <string name="ellipsis_label">Read more</string>

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/Dummies.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/Dummies.kt
@@ -1,10 +1,10 @@
 package io.github.droidkaigi.confsched2020.session.ui.viewmodel
 
 import com.soywiz.klock.DateTime
-import io.github.droidkaigi.confsched2020.model.AudienceCategory
 import io.github.droidkaigi.confsched2020.model.Category
 import io.github.droidkaigi.confsched2020.model.Lang
 import io.github.droidkaigi.confsched2020.model.LangSupport
+import io.github.droidkaigi.confsched2020.model.Level
 import io.github.droidkaigi.confsched2020.model.LocaledString
 import io.github.droidkaigi.confsched2020.model.Room
 import io.github.droidkaigi.confsched2020.model.ServiceSession
@@ -33,15 +33,16 @@ object Dummies {
         name = LocaledString(ja = "category ja", en = "category en")
     )
     val serviceSession = ServiceSession(
-        SessionId("service_session_id"),
-        1,
-        DateTime(2020, 2, 10, 10, 10, 10),
-        DateTime(2020, 2, 10, 11, 10, 10),
-        LocaledString("キーノート", "KeyNote"),
-        "Keynote of droidkaigi",
-        hall,
-        SessionType.WELCOME_TALK,
-        true
+        id = SessionId("service_session_id"),
+        dayNumber = 1,
+        startTime = DateTime(2020, 2, 10, 10, 10, 10),
+        endTime = DateTime(2020, 2, 10, 11, 10, 10),
+        title = LocaledString("キーノート", "KeyNote"),
+        desc = "Keynote of droidkaigi",
+        room = hall,
+        levels = listOf(Level.BEGINNER),
+        sessionType = SessionType.WELCOME_TALK,
+        isFavorited = true
     )
 
     val speachSession1 = SpeechSession(
@@ -62,6 +63,7 @@ object Dummies {
         isInterpretationTarget = false,
         isFavorited = false,
         speakers = speakers,
+        levels = listOf(Level.BEGINNER),
         message = null,
         lang = Lang.JA
     )
@@ -76,6 +78,6 @@ object Dummies {
         langs = listOf(Lang.JA, Lang.EN),
         langSupports = listOf(LangSupport.INTERPRETATION),
         category = listOf(category),
-        audienceCategories = listOf(AudienceCategory.BEGINNERS, AudienceCategory.UNSPECIFIED)
+        levels = listOf(Level.BEGINNER, Level.INTERMEDIATE, Level.ADVANCED)
     )
 }

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModelTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModelTest.kt
@@ -427,7 +427,7 @@ class SessionsViewModelTest {
     }
 
     @Test
-    fun filterChanged_audienceCategory_true() {
+    fun filterChanged_level_true() {
         coEvery { sessionRepository.sessionContents() } returns flowOf(Dummies.sessionContents)
 
         val sessionsViewModel = SessionsViewModel(
@@ -457,7 +457,7 @@ class SessionsViewModelTest {
     }
 
     @Test
-    fun filterChanged_audienceCategory_false() {
+    fun filterChanged_level_false() {
         coEvery { sessionRepository.sessionContents() } returns flowOf(Dummies.sessionContents)
 
         val sessionsViewModel = SessionsViewModel(

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModelTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2020/session/ui/viewmodel/SessionsViewModelTest.kt
@@ -1,11 +1,11 @@
 package io.github.droidkaigi.confsched2020.session.ui.viewmodel
 
 import com.jraska.livedata.test
-import io.github.droidkaigi.confsched2020.model.AudienceCategory
 import io.github.droidkaigi.confsched2020.model.Category
 import io.github.droidkaigi.confsched2020.model.Filters
 import io.github.droidkaigi.confsched2020.model.Lang
 import io.github.droidkaigi.confsched2020.model.LangSupport
+import io.github.droidkaigi.confsched2020.model.Level
 import io.github.droidkaigi.confsched2020.model.LocaledString
 import io.github.droidkaigi.confsched2020.model.Room
 import io.github.droidkaigi.confsched2020.model.Session
@@ -60,7 +60,7 @@ class SessionsViewModelTest {
             filters shouldBe Filters()
             allFilters shouldBe Filters(
                 rooms = Dummies.sessionContents.rooms.toSet(),
-                audienceCategories = Dummies.sessionContents.audienceCategories.toSet(),
+                levels = Dummies.sessionContents.levels.toSet(),
                 categories = Dummies.sessionContents.category.toSet(),
                 langs = Dummies.sessionContents.langs.toSet(),
                 langSupports = Dummies.sessionContents.langSupports.toSet()
@@ -95,7 +95,7 @@ class SessionsViewModelTest {
         val filters = Filters()
         val allFilters = Filters(
             rooms = Dummies.sessionContents.rooms.toSet(),
-            audienceCategories = Dummies.sessionContents.audienceCategories.toSet(),
+            levels = Dummies.sessionContents.levels.toSet(),
             categories = Dummies.sessionContents.category.toSet(),
             langs = Dummies.sessionContents.langs.toSet(),
             langSupports = Dummies.sessionContents.langSupports.toSet()
@@ -439,7 +439,7 @@ class SessionsViewModelTest {
             .uiModel
             .test()
 
-        sessionsViewModel.filterChanged(AudienceCategory.BEGINNERS, true)
+        sessionsViewModel.filterChanged(Level.BEGINNER, true)
         val valueHistory = testObserver.valueHistory()
         valueHistory[0] shouldBe SessionsViewModel.UiModel.EMPTY.copy(isLoading = true)
         valueHistory[1].apply {
@@ -451,7 +451,7 @@ class SessionsViewModelTest {
             isLoading shouldBe false
             error shouldBe null
             filters shouldBe Filters(
-                audienceCategories = setOf(AudienceCategory.BEGINNERS)
+                levels = setOf(Level.BEGINNER)
             )
         }
     }
@@ -465,21 +465,21 @@ class SessionsViewModelTest {
             sessionAlarm = sessionAlarm
         )
         // turn on once for testing.
-        sessionsViewModel.filterChanged(AudienceCategory.BEGINNERS, true)
-        sessionsViewModel.filterChanged(AudienceCategory.UNSPECIFIED, true)
+        sessionsViewModel.filterChanged(Level.BEGINNER, true)
+        sessionsViewModel.filterChanged(Level.INTERMEDIATE, true)
 
         val testObserver = sessionsViewModel
             .uiModel
             .test()
-        sessionsViewModel.filterChanged(AudienceCategory.UNSPECIFIED, false)
+        sessionsViewModel.filterChanged(Level.INTERMEDIATE, false)
         val valueHistory = testObserver.valueHistory()
         valueHistory[0].apply {
             isLoading shouldBe true
             error shouldBe null
             filters shouldBe Filters(
-                audienceCategories = setOf(
-                    AudienceCategory.BEGINNERS,
-                    AudienceCategory.UNSPECIFIED
+                levels = setOf(
+                    Level.BEGINNER,
+                    Level.INTERMEDIATE
                 )
             )
         }
@@ -487,16 +487,16 @@ class SessionsViewModelTest {
             isLoading shouldBe false
             error shouldBe null
             filters shouldBe Filters(
-                audienceCategories = setOf(
-                    AudienceCategory.BEGINNERS,
-                    AudienceCategory.UNSPECIFIED
+                levels = setOf(
+                    Level.BEGINNER,
+                    Level.INTERMEDIATE
                 )
             )
         }
         valueHistory[2].apply {
             isLoading shouldBe false
             error shouldBe null
-            filters shouldBe Filters(audienceCategories = setOf(AudienceCategory.BEGINNERS))
+            filters shouldBe Filters(levels = setOf(Level.BEGINNER))
         }
     }
 
@@ -508,7 +508,7 @@ class SessionsViewModelTest {
             sessionRepository = sessionRepository,
             sessionAlarm = sessionAlarm
         )
-        sessionsViewModel.filterChanged(AudienceCategory.BEGINNERS, true)
+        sessionsViewModel.filterChanged(Level.BEGINNER, true)
         sessionsViewModel.filterChanged(LangSupport.INTERPRETATION, true)
         sessionsViewModel.filterChanged(Lang.JA, true)
         val category1 = Category(
@@ -533,7 +533,7 @@ class SessionsViewModelTest {
                 categories = setOf(category1),
                 langs = setOf(Lang.JA),
                 langSupports = setOf(LangSupport.INTERPRETATION),
-                audienceCategories = setOf(AudienceCategory.BEGINNERS)
+                levels = setOf(Level.BEGINNER)
             )
         }
         valueHistory[1].apply {
@@ -544,7 +544,7 @@ class SessionsViewModelTest {
                 categories = setOf(category1),
                 langs = setOf(Lang.JA),
                 langSupports = setOf(LangSupport.INTERPRETATION),
-                audienceCategories = setOf(AudienceCategory.BEGINNERS)
+                levels = setOf(Level.BEGINNER)
             )
         }
         valueHistory[2].apply {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -9,7 +9,6 @@ apply plugin: 'kotlin-android-extensions'
 
 apply from: rootProject.file('gradle/android.gradle')
 
-
 androidExtensions {
     experimental = true
     features = ["parcelize"]

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -15,6 +15,7 @@ androidExtensions {
     features = ["parcelize"]
 }
 kotlin {
+    jvm()
     android("android")
     iosArm64("iosArm64") {
         binaries {
@@ -56,6 +57,7 @@ kotlin {
         jvmMain {
             dependencies {
                 implementation Dep.Kotlin.stdlibJvm
+                implementation Dep.Kotlin.coroutines
             }
         }
         androidMain {

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/AudienceCategory.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/AudienceCategory.kt
@@ -1,6 +1,0 @@
-package io.github.droidkaigi.confsched2020.model
-
-enum class AudienceCategory(val text: LocaledString) {
-    BEGINNERS(LocaledString("初心者歓迎", "Beginners")),
-    UNSPECIFIED(LocaledString("指定無し", "Unspecified"))
-}

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Filters.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Filters.kt
@@ -5,7 +5,7 @@ data class Filters(
     val categories: Set<Category> = mutableSetOf(),
     val langs: Set<Lang> = mutableSetOf(),
     val langSupports: Set<LangSupport> = mutableSetOf(),
-    val audienceCategories: Set<AudienceCategory> = mutableSetOf()
+    val levels: Set<Level> = mutableSetOf()
 ) {
     fun isPass(
         session: Session
@@ -31,10 +31,15 @@ data class Filters(
                 true
             }
         }
+        val levelsFilterOk = run {
+            if (levels.isEmpty()) return@run true
+            return@run session.levels.intersect(levels).isNotEmpty()
+        }
         return roomFilterOk &&
             categoryFilterOk &&
             langFilterOk &&
-            langSupportFilterOk
+            langSupportFilterOk &&
+            levelsFilterOk
     }
 
     fun isFiltered(): Boolean {
@@ -42,7 +47,7 @@ data class Filters(
             categories.isNotEmpty() ||
             langs.isNotEmpty() ||
             langSupports.isNotEmpty() ||
-            audienceCategories.isNotEmpty()
+            levels.isNotEmpty()
     }
 
     private fun Session.isNotFilterableServiceSession() =

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Level.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Level.kt
@@ -1,0 +1,14 @@
+package io.github.droidkaigi.confsched2020.model
+
+enum class Level(val rawValue: LocaledString) {
+    BEGINNER(LocaledString("初級", "Beginner")),
+    INTERMEDIATE(LocaledString("中級", "Intermediate")),
+    ADVANCED(LocaledString("上級", "Advanced"));
+
+    companion object {
+        fun findLevel(name: String): Level {
+            // if it returns null, the sever response is broken.
+            return values().find { it.name == name }!!
+        }
+    }
+}

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Level.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Level.kt
@@ -1,14 +1,14 @@
 package io.github.droidkaigi.confsched2020.model
 
-enum class Level(val rawValue: LocaledString) {
-    BEGINNER(LocaledString("初級", "Beginner")),
-    INTERMEDIATE(LocaledString("中級", "Intermediate")),
-    ADVANCED(LocaledString("上級", "Advanced"));
+enum class Level(val id: String, val rawValue: LocaledString) {
+    BEGINNER("BEGINNER", LocaledString("初級", "Beginner")),
+    INTERMEDIATE("INTERMEDIATE", LocaledString("中級", "Intermediate")),
+    ADVANCED("ADVANCED", LocaledString("上級", "Advanced"));
 
     companion object {
         fun findLevel(name: String): Level {
             // if it returns null, the sever response is broken.
-            return values().find { it.name == name }!!
+            return values().find { it.id == name }!!
         }
     }
 }

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
@@ -99,7 +99,17 @@ data class SpeechSession(
     override val isFavorited: Boolean,
     val speakers: List<Speaker>,
     val message: LocaledString?
-) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited, levels), AndroidParcel {
+) : Session(
+    id,
+    title,
+    desc,
+    dayNumber,
+    startTime,
+    endTime,
+    room,
+    isFavorited,
+    levels
+), AndroidParcel {
 
     override fun shortSummary(lang: Lang) = buildString {
         append(timeInMinutes)
@@ -125,7 +135,17 @@ data class ServiceSession(
     override val levels: List<Level>,
     val sessionType: SessionType,
     override val isFavorited: Boolean
-) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited, levels), AndroidParcel {
+) : Session(
+    id,
+    title,
+    desc,
+    dayNumber,
+    startTime,
+    endTime,
+    room,
+    isFavorited,
+    levels
+), AndroidParcel {
 
     override fun shortSummary(lang: Lang) = buildString {
         append(timeInMinutes)

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/Session.kt
@@ -12,7 +12,8 @@ sealed class Session(
     open val startTime: DateTime,
     open val endTime: DateTime,
     open val room: Room,
-    open val isFavorited: Boolean
+    open val isFavorited: Boolean,
+    open val levels: List<Level>
 ) {
     val startDayText by lazy { startTime.toOffset(defaultTimeZoneOffset()).format("yyyy.M.d") }
 
@@ -88,6 +89,7 @@ data class SpeechSession(
     override val title: LocaledString,
     override val desc: String,
     override val room: Room,
+    override val levels: List<Level>,
     val lang: Lang,
     val category: Category,
     val intendedAudience: String?,
@@ -97,7 +99,7 @@ data class SpeechSession(
     override val isFavorited: Boolean,
     val speakers: List<Speaker>,
     val message: LocaledString?
-) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited), AndroidParcel {
+) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited, levels), AndroidParcel {
 
     override fun shortSummary(lang: Lang) = buildString {
         append(timeInMinutes)
@@ -120,9 +122,10 @@ data class ServiceSession(
     override val title: LocaledString,
     override val desc: String,
     override val room: Room,
+    override val levels: List<Level>,
     val sessionType: SessionType,
     override val isFavorited: Boolean
-) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited), AndroidParcel {
+) : Session(id, title, desc, dayNumber, startTime, endTime, room, isFavorited, levels), AndroidParcel {
 
     override fun shortSummary(lang: Lang) = buildString {
         append(timeInMinutes)

--- a/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionContents.kt
+++ b/model/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/model/SessionContents.kt
@@ -7,7 +7,7 @@ data class SessionContents(
     val langs: List<Lang>,
     val langSupports: List<LangSupport>,
     val category: List<Category>,
-    val audienceCategories: List<AudienceCategory>
+    val levels: List<Level>
 ) {
     companion object {
         val EMPTY = SessionContents(

--- a/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2020/model/FiltersTest.kt
+++ b/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2020/model/FiltersTest.kt
@@ -14,8 +14,8 @@ import org.junit.runners.Parameterized
 class FiltersTest {
 
     private companion object {
-        val room1 = Room(10, "room1")
-        val room2 = Room(11, "room2")
+        val room1 = Room(10, LocaledString("部屋1", "room1"), 0)
+        val room2 = Room(11, LocaledString("部屋2", "room2"), 0)
         val category1 = Category(10, LocaledString("ツール1", "Tool1"))
         val category2 = Category(11, LocaledString("ツール2", "Tool2"))
     }
@@ -156,50 +156,61 @@ class FiltersTest {
                     },
                     expected = false
                 ),
-                Param.forAudienceCategory(
-                    title = "empty filter passes beginners session",
-                    isForBeginners = true,
+                Param.forLevels(
+                    title = "empty filter passes beginner session",
+                    levelList = listOf(Level.BEGINNER),
                     expected = true
                 ),
-                Param.forAudienceCategory(
-                    title = "empty filter passes non beginners session",
-                    isForBeginners = false,
+                Param.forLevels(
+                    title = "empty filter passes intermediate session",
+                    levelList = listOf(Level.INTERMEDIATE),
                     expected = true
                 ),
-                Param.forAudienceCategory(
+                Param.forLevels(
+                    title = "empty filter passes advanced session",
+                    levelList = listOf(Level.ADVANCED),
+                    expected = true
+                ),
+                Param.forLevels(
                     title = "Beginners filter passes beginners session",
-                    filterItem = setOf(AudienceCategory.BEGINNERS),
-                    isForBeginners = true,
+                    filterItem = setOf(Level.BEGINNER),
+                    levelList = listOf(Level.BEGINNER),
                     expected = true
                 ),
-                Param.forAudienceCategory(
+                Param.forLevels(
                     title = "Beginners filter does not pass non beginners session",
-                    filterItem = setOf(AudienceCategory.BEGINNERS),
-                    isForBeginners = false,
+                    filterItem = setOf(Level.BEGINNER),
+                    levelList = listOf(Level.INTERMEDIATE),
                     expected = false
                 ),
-                Param.forAudienceCategory(
-                    title = "Unspecified filter does not pass beginners session",
-                    filterItem = setOf(AudienceCategory.UNSPECIFIED),
-                    isForBeginners = true,
+                Param.forLevels(
+                    title = "filter has Beginners passes Beginners and Intermediate session",
+                    filterItem = setOf(Level.BEGINNER),
+                    levelList = listOf(Level.BEGINNER, Level.INTERMEDIATE),
+                    expected = true
+                ),
+                Param.forLevels(
+                    title = "filter has Advanced not passes Beginners and Intermediate session",
+                    filterItem = setOf(Level.ADVANCED),
+                    levelList = listOf(Level.BEGINNER, Level.INTERMEDIATE),
                     expected = false
                 ),
-                Param.forAudienceCategory(
-                    title = "Unspecified filter passes non beginners session",
-                    filterItem = setOf(AudienceCategory.UNSPECIFIED),
-                    isForBeginners = false,
+                Param.forLevels(
+                    title = "filter has Beginners and Intermediate passes beginners session",
+                    filterItem = setOf(Level.BEGINNER, Level.INTERMEDIATE),
+                    levelList = listOf(Level.BEGINNER),
                     expected = true
                 ),
-                Param.forAudienceCategory(
-                    title = "filter has Beginners and Unspecified passes beginners session",
-                    filterItem = setOf(AudienceCategory.BEGINNERS, AudienceCategory.UNSPECIFIED),
-                    isForBeginners = true,
-                    expected = true
+                Param.forLevels(
+                    title = "filter has Beginners and Intermediate not passes Advanced session",
+                    filterItem = setOf(Level.BEGINNER, Level.INTERMEDIATE),
+                    levelList = listOf(Level.ADVANCED),
+                    expected = false
                 ),
-                Param.forAudienceCategory(
-                    title = "filter has Beginners and Unspecified passes non beginners session",
-                    filterItem = setOf(AudienceCategory.BEGINNERS, AudienceCategory.UNSPECIFIED),
-                    isForBeginners = false,
+                Param.forLevels(
+                    title = "filter has Beginners and Intermediate passes Intermediate and Advanced session",
+                    filterItem = setOf(Level.BEGINNER, Level.INTERMEDIATE),
+                    levelList = listOf(Level.INTERMEDIATE, Level.ADVANCED),
                     expected = true
                 )
             )
@@ -228,16 +239,16 @@ data class Param<T>(
     override fun toString(): String = title
 
     companion object {
-        fun forAudienceCategory(
+        fun forLevels(
             title: String,
-            filterItem: Set<AudienceCategory> = setOf(),
-            isForBeginners: Boolean,
+            filterItem: Set<Level> = setOf(),
+            levelList: List<Level>,
             expected: Boolean
         ) = Param<SpeechSession>(
             title = title,
-            filters = Filters(audienceCategories = filterItem),
+            filters = Filters(levels = filterItem),
             sessionSetup = {
-                every { forBeginners } returns isForBeginners
+                every { levels } returns levelList
             },
             expected = expected
         )

--- a/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2020/model/FiltersTest.kt
+++ b/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2020/model/FiltersTest.kt
@@ -208,7 +208,8 @@ class FiltersTest {
                     expected = false
                 ),
                 Param.forLevels(
-                    title = "filter has Beginners and Intermediate passes Intermediate and Advanced session",
+                    title = "filter has Beginners and Intermediate" +
+                        " passes Intermediate and Advanced session",
                     filterItem = setOf(Level.BEGINNER, Level.INTERMEDIATE),
                     levelList = listOf(Level.INTERMEDIATE, Level.ADVANCED),
                     expected = true


### PR DESCRIPTION
## Issue
- close #709 

## Overview (Required)
- rename AudienceCategory to Level
- create member level to Session model
- create LevelEntity
- fix FilterTest
- rename AudienceCategory to Level

日本語でこの変更を行った理由と私の思いについて書かせてください．
まず，AudienceCategoryという名前は去年のものだと思いますが，今年はLevelということで，視聴者のレベルではなく，セッションそのもののレベルであり，これは，セッションそのものの特性を指していることから，すべてのAudienceCategoryと名のついたものをLevelという名前に変えさせていただきました．
その際，iOS側のクラスの名前も変わってしまうことになります（なるはずですよね？）が，iOSではまだフィルターは実装されておらず，変更の効く範囲だと思いますので，このようにさせていただきました．
また，セッションのエンティティに`levels`という要素が加わったことにより，キャッシュのデータベースが変更されました．この事により，アプリのストレージをクリアしないとアップデート時に機能しなくなりますが，マイグレーションの処理は書いていません．理由としては，このアプリはまだPlayStoreに上がっておらず，開発段階であり，開発者の皆さまがアプリを再インストールすることで使えるようになるならば，スピード感を優先してマイグレーションはつけなくて良いと判断したためです．
最後に，テストについてです．今回私がいじったのは`model`モジュールですが，このモジュールの`jvmTest`モジュールはなぜかテストとして認識されていませんでした．`model/build.gradle`を見ると，`jvm()`の記述がなかったため，それを追加することにより`jvmTest`が動くようにしました．また，FilterTestに関しましては，今回の変更ですべてのパターンを調べると18通りとなり，非常に記述が長くなってしまうため，最小限ですべてのパターンを調べることができているように記述したつもりです．

## Links
- #614 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6965122/73733843-04321b00-4780-11ea-8a33-6ad2257dd661.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6965122/73733706-c8975100-477f-11ea-87da-53f27fd5c18a.png" width="300" />
