### PR TITLE
Crash when click share button in welcome talk detail

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -132,7 +132,7 @@ class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Inject
             val session = binding.session ?: return@setOnMenuItemClickListener true
             when (menuItem.itemId) {
                 R.id.session_share -> {
-                    val sessionId = session.id.id.toInt()
+                    val sessionId = session.id.id
                     val url = resources.getString(R.string.session_share_url).format(sessionId)
                     systemViewModel.shareURL(
                         activity = requireActivity(),

--- a/feature/session/src/main/res/values-ja/strings.xml
+++ b/feature/session/src/main/res/values-ja/strings.xml
@@ -14,5 +14,5 @@
     <string name="empty_favorite_session">お気に入りのセッションを登録するとあなた専用のプランを作ることができます。</string>
     <string name="time_icon">時計アイコン</string>
     <string name="favorite_icon">お気に入りアイコン</string>
-    <string name="session_share_url">https://droidkaigi.jp/2020/timetable/%d</string>
+    <string name="session_share_url">https://droidkaigi.jp/2020/timetable/%s</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -23,5 +23,5 @@
     <string name="empty_favorite_session">You choose your favorite sessions, then you can make a plan for you.</string>
     <string name="time_icon">Time Icon</string>
     <string name="favorite_icon">Favorite Icon</string>
-    <string name="session_share_url">https://droidkaigi.jp/2020/en/timetable/%d</string>
+    <string name="session_share_url">https://droidkaigi.jp/2020/en/timetable/%s</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #719

## Overview (Required)
- `ServiceSession.id` is not an integer.
- Stop converting to integer.

## Screenshot

### Before
Crash when click share button in welcome talk detail.

### After

Click share button
<img src="https://user-images.githubusercontent.com/9940385/73916542-feb00e80-4900-11ea-80a8-a9304af96e2f.png" width="200" />

Share to Twitter
<img src="https://user-images.githubusercontent.com/9940385/73916553-02dc2c00-4901-11ea-933c-047f1d1a3ad3.png" width="200" /> <img src="https://user-images.githubusercontent.com/9940385/73916555-040d5900-4901-11ea-88a5-ecedf4991a83.png" width="200" />

Open URL shared on Twitter
<img src="https://user-images.githubusercontent.com/9940385/73916565-066fb300-4901-11ea-9690-f567f21568b6.png" width="200" />
