### PR TITLE
Fix wrong status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![DroidKaigi Logo](corecomponent/androidcomponent/src/main/res/drawable-xxhdpi/ic_logo.png)DroidKaigi 2020 official Android app
 
-[![GitHub Actions](https://github.com/DroidKaigi/conference-app-2020/workflows/.github/workflows/on_release_branch.yml/badge.svg)](https://github.com/DroidKaigi/conference-app-2020/actions?query=workflow%3A%22On+release+branch%22)
+[![GitHub Actions](https://github.com/DroidKaigi/conference-app-2020/workflows/On%20release%20branch/badge.svg)](https://github.com/DroidKaigi/conference-app-2020/actions?query=workflow%3A%22On+release+branch%22)
 
 We are currently working on the event. We are looking for contributors!
 


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Fix wrong status badge URL

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6157540/73917376-9eba6780-4902-11ea-9883-8329976d3678.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6157540/73917387-a417b200-4902-11ea-933a-f50fb7062e7f.png" width="300" />