### PR TITLE
Add style Theme.DroidKaigi.ActionBar for dark theme

### DIFF
--- a/corecomponent/androidcomponent/src/main/res/values-night/themes.xml
+++ b/corecomponent/androidcomponent/src/main/res/values-night/themes.xml
@@ -18,4 +18,11 @@
 
     <style name="Theme.DroidKaigi.DayNight" parent="Theme.DroidKaigi.Dark" />
 
+    <style name="Theme.DroidKaigi.ActionBar" parent="Theme.DroidKaigi.Dark">
+        <item name="windowActionBar">true</item>
+        <item name="windowNoTitle">false</item>
+
+        <item name="colorPrimary">@color/black</item>
+        <item name="colorPrimaryDark">@color/gray</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- Add a style `Theme.DroidKaigi.ActionBar` to adapt license page to dark theme


## Links
- https://github.com/DroidKaigi/conference-app-2020/issues/713#issuecomment-582219857
  - Thanks @clockvoid san for your report :)

## Screenshot

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7891554/73940703-451c6200-492f-11ea-9117-c66129663ca0.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7891554/73940662-303fce80-492f-11ea-86de-93795407e7ce.png" width="300" />

tested device: Pixel 3
OS version: 10