### PR TITLE
Fix deprecated PreferenceManager.

### DIFF
--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api Dep.AndroidX.coreKtx
     api Dep.AndroidX.liveDataKtx
     api Dep.AndroidX.liveDataCoreKtx
+    api Dep.AndroidX.preference
     implementation Dep.AndroidX.Work.runtimeKtx
     implementation Dep.liveEvent
 

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/Prefs.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2020/util/Prefs.kt
@@ -1,7 +1,7 @@
 package io.github.droidkaigi.confsched2020.util
 
 import android.content.Context
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 import io.github.droidkaigi.confsched2020.widget.component.R
 


### PR DESCRIPTION
## Issue
- close #739

## Overview (Required)
- Fix deprecated PreferenceManager. The android.preference has been updated to androidx.preference.

## Links
- https://developer.android.com/reference/android/preference/package-summary
- https://developer.android.com/reference/androidx/preference/package-summary
