### PR TITLE
Fix a bug that the BottomAppBar is not close to the FAB

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2020.session.ui
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.IdRes
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -128,35 +129,44 @@ class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Inject
                     }
             }
 
-        binding.bottomAppBar.setOnMenuItemClickListener { menuItem ->
-            val session = binding.session ?: return@setOnMenuItemClickListener true
-            when (menuItem.itemId) {
-                R.id.session_share -> {
-                    val sessionId = session.id.id
-                    val url = resources.getString(R.string.session_share_url).format(sessionId)
-                    systemViewModel.shareURL(
-                        activity = requireActivity(),
-                        url = url
-                    )
-                }
-                R.id.floormap -> {
-                    val directions = actionSessionToFloormap(session.room)
-                    findNavController().navigate(directions)
-                }
-                R.id.session_calendar -> {
-                    systemViewModel.sendEventToCalendar(
-                        activity = requireActivity(),
-                        title = session.title.getByLang(defaultLang()),
-                        location = session.room.name.getByLang(defaultLang()),
-                        startDateTime = session.startTime,
-                        endDateTime = session.endTime
-                    )
-                }
-                else -> {
-                    handleNavigation(menuItem.itemId)
-                }
+        binding.bottomAppBar.run {
+            doOnNextLayout {
+                measure(
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+                    View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+                )
             }
-            return@setOnMenuItemClickListener true
+            setOnMenuItemClickListener { menuItem ->
+                val session = binding.session ?: return@setOnMenuItemClickListener true
+
+                when (menuItem.itemId) {
+                    R.id.session_share -> {
+                        val sessionId = session.id.id
+                        val url = resources.getString(R.string.session_share_url).format(sessionId)
+                        systemViewModel.shareURL(
+                            activity = requireActivity(),
+                            url = url
+                        )
+                    }
+                    R.id.floormap -> {
+                        val directions = actionSessionToFloormap(session.room)
+                        findNavController().navigate(directions)
+                    }
+                    R.id.session_calendar -> {
+                        systemViewModel.sendEventToCalendar(
+                            activity = requireActivity(),
+                            title = session.title.getByLang(defaultLang()),
+                            location = session.room.name.getByLang(defaultLang()),
+                            startDateTime = session.startTime,
+                            endDateTime = session.endTime
+                        )
+                    }
+                    else -> {
+                        handleNavigation(menuItem.itemId)
+                    }
+                }
+                return@setOnMenuItemClickListener true
+            }
         }
     }
 


### PR DESCRIPTION
## Issue
- close #62 

## Overview (Required)
The cause of this issue is that the BottomAppBar cannot calculate its height correctly in API level 21 environment.
So I added process to measure own size when #doOnNextLayout is called.

## Links
- N/A

## Screenshot
| | Before | After
| :--: | :--: | :--:
| Nexus5 Android5.0 | <img src="https://user-images.githubusercontent.com/33515193/74086280-ab86b900-4ac4-11ea-9bf8-957df48e746d.png" width="320" /> | <img src="https://user-images.githubusercontent.com/33515193/74086250-74b0a300-4ac4-11ea-98ae-d304200ff70c.png" width="320" />