### PR TITLE
[iOS]add release scheme and specify debug scheme

### DIFF
--- a/ios-base/project.yml
+++ b/ios-base/project.yml
@@ -1,6 +1,37 @@
 name: DroidKaigi 2020
 settings:
     PRODUCT_BUNDLE_IDENTIFIER: io.github.droidkaigi.confsched2020.DroidKaigi-2020
+schemes:
+  DroidKaigi 2020-Debug:
+    build:
+      targets:
+        DroidKaigi 2020: all
+        DroidKaigi 2020UITests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+    profile: 
+      config: Debug
+    analyze:
+      config: Debug
+    archive: 
+      config: Debug
+  DroidKaigi 2020-Release:
+    build:
+      targets:
+        DroidKaigi 2020: all
+        DroidKaigi 2020UITests: [test]
+    run:
+      config: Release
+    test:
+      config: Release
+    profile: 
+      config: Release
+    analyze:
+      config: Release
+    archive: 
+      config: Release
 targets:
     DroidKaigi 2020:
         type: application


### PR DESCRIPTION
## Issue
- close N/A
ref: https://github.com/DroidKaigi/conference-app-2020/issues/747#issuecomment-583845508

## Overview (Required)
- Add `Release` scheme for iOS project.
<img width="300" alt="スクリーンショット 2020-02-10 0 11 56" src="https://user-images.githubusercontent.com/30540303/74104638-f8888f00-4b99-11ea-8158-bb4501f04bf9.png">


## Links
-

## Screenshot(Event tab)
Debug | Release
:--: | :--:
<img src="https://user-images.githubusercontent.com/30540303/74104459-1228d700-4b98-11ea-9cfb-44c7660307fe.png" width="300" />|<img src="https://user-images.githubusercontent.com/30540303/74104457-0f2de680-4b98-11ea-9e03-355be6975ac4.png" width="300" />
