### PR TITLE
[iOS] Rename ios_combined to ioscombined

### DIFF
--- a/ios-base/DroidKaigi 2020/Announcements/Models/AnnouncementsDataProvider.swift
+++ b/ios-base/DroidKaigi 2020/Announcements/Models/AnnouncementsDataProvider.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxSwift
 
 protocol AnnouncementsDataProviderProtocol {

--- a/ios-base/DroidKaigi 2020/Announcements/ViewModels/AnnouncementsViewModel.swift
+++ b/ios-base/DroidKaigi 2020/Announcements/ViewModels/AnnouncementsViewModel.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 

--- a/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsDataSource.swift
+++ b/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsDataSource.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import UIKit

--- a/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsViewController.swift
+++ b/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import UIKit

--- a/ios-base/DroidKaigi 2020/Announcements/Views/Cells/AnnouncementCell.swift
+++ b/ios-base/DroidKaigi 2020/Announcements/Views/Cells/AnnouncementCell.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import UIKit
 
 private extension Announcement.Type_ {

--- a/ios-base/DroidKaigi 2020/Common/Components/CategoryLabel.swift
+++ b/ios-base/DroidKaigi 2020/Common/Components/CategoryLabel.swift
@@ -1,9 +1,8 @@
+import ioscombined
 import UIKit
-import ios_combined
 
 @IBDesignable
 class CategoryLabel: UILabel {
-
     private var padding: UIEdgeInsets = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
 
     override func drawText(in rect: CGRect) {

--- a/ios-base/DroidKaigi 2020/Extentions/LangParameter+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/LangParameter+Ex.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ios_combined
+import ioscombined
 
 extension LangParameter {
     static func from(_ lang: Lang) -> LangParameter {

--- a/ios-base/DroidKaigi 2020/Extentions/LocaledString+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/LocaledString+Ex.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 
 extension LocaledString {
     var currentLangString: String {

--- a/ios-base/DroidKaigi 2020/Extentions/SearchResult+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/SearchResult+Ex.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 
 extension SearchResult {
     static func empty() -> SearchResult {

--- a/ios-base/DroidKaigi 2020/Extentions/Session+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/Session+Ex.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ios_combined
+import ioscombined
 
 extension Session {
     var timeRoomText: String {

--- a/ios-base/DroidKaigi 2020/Extentions/SessionContents+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/SessionContents+Ex.swift
@@ -1,8 +1,7 @@
-import ios_combined
+import ioscombined
 
 extension SessionContents {
     static func empty() -> SessionContents {
         return .init(sessions: [], speakers: [], rooms: [], langs: [], langSupports: [], category: [], levels: [])
     }
 }
-

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import UIKit
 
 final class FloorMapViewController: ContentViewController {

--- a/ios-base/DroidKaigi 2020/Search/ViewModels/SearchViewModel.swift
+++ b/ios-base/DroidKaigi 2020/Search/ViewModels/SearchViewModel.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 

--- a/ios-base/DroidKaigi 2020/Search/Views/Cells/ResultSpeakerCell.swift
+++ b/ios-base/DroidKaigi 2020/Search/Views/Cells/ResultSpeakerCell.swift
@@ -1,9 +1,8 @@
-import ios_combined
+import ioscombined
 import Nuke
 import UIKit
 
 final class ResultSpeakerCell: UICollectionViewCell {
-
     static let rowHeight: CGFloat = 60
     static let identifier = "ResultSpeakerCell"
 
@@ -13,6 +12,7 @@ final class ResultSpeakerCell: UICollectionViewCell {
             speakerIcon.clipsToBounds = true
         }
     }
+
     @IBOutlet weak var speakerNameLabel: UILabel!
 
     func configure(speaker: Speaker) {

--- a/ios-base/DroidKaigi 2020/Search/Views/SearchContentsDataSource.swift
+++ b/ios-base/DroidKaigi 2020/Search/Views/SearchContentsDataSource.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import UIKit

--- a/ios-base/DroidKaigi 2020/Search/Views/SearchContentsViewController.swift
+++ b/ios-base/DroidKaigi 2020/Search/Views/SearchContentsViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import Material
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020/Session/Detail/SessionDetailViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Detail/SessionDetailViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import Nuke
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020/Session/Models/BookingSessionProvider.swift
+++ b/ios-base/DroidKaigi 2020/Session/Models/BookingSessionProvider.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 import RxRealm
 import RxSwift
@@ -18,7 +18,7 @@ final class BookingSessionProvider {
     }
 
     // 1582160400 is 2/20 10:00
-    func fetchBookedSessions(firstSessionStartTime: TimeInterval = 1582160400) -> Observable<[Session]> {
+    func fetchBookedSessions(firstSessionStartTime: TimeInterval = 1_582_160_400) -> Observable<[Session]> {
         do {
             let realm = try Realm()
             let result = realm.objects(SessionEntity.self)

--- a/ios-base/DroidKaigi 2020/Session/Models/FilterService.swift
+++ b/ios-base/DroidKaigi 2020/Session/Models/FilterService.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 
 protocol FilterServiceProtocol {
     func filterSessions(_ sessions: [Session], by sessionContents: FilterSessionContents) -> [Session]

--- a/ios-base/DroidKaigi 2020/Session/Models/FilterSessionContents.swift
+++ b/ios-base/DroidKaigi 2020/Session/Models/FilterSessionContents.swift
@@ -1,13 +1,13 @@
-import ios_combined
+import ioscombined
 
 struct FilterSessionContents {
     var rooms: [Room]
     var langs: [Lang]
     var levels: [Level]
-    var categories: [ios_combined.Category]
+    var categories: [ioscombined.Category]
     var langSupports: [LangSupport]
 
-    init(rooms: [Room], langs: [Lang], levels: [Level], categories: [ios_combined.Category], langSupports: [LangSupport]) {
+    init(rooms: [Room], langs: [Lang], levels: [Level], categories: [ioscombined.Category], langSupports: [LangSupport]) {
         self.rooms = rooms
         self.langs = langs
         self.levels = levels
@@ -16,11 +16,11 @@ struct FilterSessionContents {
     }
 
     init(sessionContents: SessionContents) {
-        self.rooms = sessionContents.rooms
-        self.langs = sessionContents.langs
-        self.levels = sessionContents.levels
-        self.categories = sessionContents.category
-        self.langSupports = sessionContents.langSupports
+        rooms = sessionContents.rooms
+        langs = sessionContents.langs
+        levels = sessionContents.levels
+        categories = sessionContents.category
+        langSupports = sessionContents.langSupports
     }
 
     static func empty() -> FilterSessionContents {

--- a/ios-base/DroidKaigi 2020/Session/Models/SessionDataProvider.swift
+++ b/ios-base/DroidKaigi 2020/Session/Models/SessionDataProvider.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxSwift
 
 final class SessionDataProvider {

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/CategoryEntity.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/CategoryEntity.swift
@@ -1,19 +1,18 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 
 final class CategoryEntity: Object {
     @objc dynamic var id: Int = 0
     @objc dynamic var name: String = ""
     @objc dynamic var enName: String = ""
-    
-    init(category: ios_combined.Category) {
+
+    init(category: ioscombined.Category) {
         id = Int(category.id)
         name = category.name.ja
         enName = category.name.en
     }
-    
+
     required init() {
         super.init()
     }
 }
-

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/Mapper/RealmToModelMapper.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/Mapper/RealmToModelMapper.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 
 final class RealmToModelMapper {
     static func toModel(sessionEntity session: SessionEntity, firstSessionSTime firstSTime: TimeInterval) -> Session? {

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/RoomEnitity.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/RoomEnitity.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 
 final class RoomEntity: Object {
@@ -6,14 +6,14 @@ final class RoomEntity: Object {
     @objc dynamic var name: String = ""
     @objc dynamic var enName: String = ""
     @objc dynamic var sort: Int = 0
-    
+
     init(room: Room) {
         id = Int(room.id)
         name = room.name.ja
         enName = room.name.en
         sort = Int(room.sort)
     }
-    
+
     required init() {
         super.init()
     }

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/SessionEntity.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/SessionEntity.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 
 final class SessionEntity: Object {

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/SpeakerEntity.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/SpeakerEntity.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 
 class SpeakerEntity: Object {
@@ -7,7 +7,7 @@ class SpeakerEntity: Object {
     @objc dynamic var tagLine: String?
     @objc dynamic var bio: String?
     @objc dynamic var imageUrl: String?
-    
+
     init(speaker: Speaker) {
         id = speaker.id.id
         name = speaker.name
@@ -15,7 +15,7 @@ class SpeakerEntity: Object {
         bio = speaker.bio
         imageUrl = speaker.imageUrl
     }
-    
+
     required init() {
         super.init()
     }

--- a/ios-base/DroidKaigi 2020/Session/ViewModels/FilterViewModel.swift
+++ b/ios-base/DroidKaigi 2020/Session/ViewModels/FilterViewModel.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 
@@ -67,7 +67,7 @@ final class FilterViewModel: FilterViewModelType {
                     sessionContents.langs.append(lang)
                 case let level as Level:
                     sessionContents.levels.append(level)
-                case let category as ios_combined.Category:
+                case let category as ioscombined.Category:
                     sessionContents.categories.append(category)
                 case let langSupport as LangSupport:
                     sessionContents.langSupports.append(langSupport)
@@ -94,7 +94,7 @@ final class FilterViewModel: FilterViewModelType {
                     if let index = sessionContents.levels.firstIndex(of: level) {
                         sessionContents.levels.remove(at: index)
                     }
-                case let category as ios_combined.Category:
+                case let category as ioscombined.Category:
                     if let index = sessionContents.categories.firstIndex(of: category) {
                         sessionContents.categories.remove(at: index)
                     }

--- a/ios-base/DroidKaigi 2020/Session/ViewModels/SessionViewModel.swift
+++ b/ios-base/DroidKaigi 2020/Session/ViewModels/SessionViewModel.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RealmSwift
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020/Session/Views/FilterViewDataSource.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/FilterViewDataSource.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import UIKit

--- a/ios-base/DroidKaigi 2020/Session/Views/SessionViewController.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/SessionViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import MaterialComponents
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020/Session/Views/SessionViewDataSource.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/SessionViewDataSource.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import MaterialComponents
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020/Speaker/Views/SpeakerViewController.swift
+++ b/ios-base/DroidKaigi 2020/Speaker/Views/SpeakerViewController.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ios_combined
+import ioscombined
 import Nuke
 import UIKit
 

--- a/ios-base/DroidKaigi 2020/Sponsor/Models/SponsorDataProvider.swift
+++ b/ios-base/DroidKaigi 2020/Sponsor/Models/SponsorDataProvider.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxSwift
 
 final class SponsorDataProvider {

--- a/ios-base/DroidKaigi 2020/Sponsor/ViewModels/SponsorViewModel.swift
+++ b/ios-base/DroidKaigi 2020/Sponsor/ViewModels/SponsorViewModel.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 

--- a/ios-base/DroidKaigi 2020/Sponsor/Views/SponsorViewController.swift
+++ b/ios-base/DroidKaigi 2020/Sponsor/Views/SponsorViewController.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import SafariServices

--- a/ios-base/DroidKaigi 2020/Sponsor/Views/SponsorViewDataSource.swift
+++ b/ios-base/DroidKaigi 2020/Sponsor/Views/SponsorViewDataSource.swift
@@ -1,4 +1,4 @@
-import ios_combined
+import ioscombined
 import Nuke
 import RxCocoa
 import RxSwift

--- a/ios-base/DroidKaigi 2020Tests/Announcements/AnnouncementsViewControllerTests.swift
+++ b/ios-base/DroidKaigi 2020Tests/Announcements/AnnouncementsViewControllerTests.swift
@@ -1,5 +1,5 @@
 @testable import DroidKaigi_2020
-import ios_combined
+import ioscombined
 import RxCocoa
 import RxSwift
 import SnapshotTesting


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- I missed module name at import changing.
- Rename `ios_combined` to `ioscombined`

## Links
- https://github.com/DroidKaigi/conference-app-2020/pull/761

## Screenshot
