### PR TITLE
fix expand animation.

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -244,7 +244,6 @@ class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Inject
                 }
             }
         )
-        adapter.clear()
         adapter.update(items)
         startPostponedEnterTransition()
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/SessionDetailFragment.kt
@@ -244,6 +244,7 @@ class SessionDetailFragment : Fragment(R.layout.fragment_session_detail), Inject
                 }
             }
         )
+        adapter.clear()
         adapter.update(items)
         startPostponedEnterTransition()
 

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -19,6 +19,7 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:descendantFocusability="blocksDescendants"
         tools:theme="@style/Theme.DroidKaigi"
         >
 


### PR DESCRIPTION
## Issue
- close #751

## Overview (Required)
This issue can be avoided by running "adapter.clear()" before "adapter.update(items)" in the setupSessionViews method of the SessionDetailFragment class.

When "adapter.clear()" is run, "notifyItemRangeInserted()" works.
When "adapter.clear()" is not run, "notifyItemRangeChanged()" works.

![01](https://user-images.githubusercontent.com/60731158/74143880-fc222180-4c3e-11ea-91d1-03179560cde5.gif)
