### PR TITLE
Fix a bug that the session title is not translated

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
@@ -87,7 +87,7 @@ class SessionItem @AssistedInject constructor(
             itemRoot.transitionName = "${session.id}-$TRANSITION_NAME_SUFFIX"
             live.isVisible = session.isOnGoing
             bindSessionMessage(session, viewBinding)
-            title.text = session.title.ja
+            title.text = session.title.getByLang(defaultLang())
             title.setSearchHighlight()
             room.text = session.minutesRoom(defaultLang())
             imageRequestDisposables.clear()

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionItem.kt
@@ -80,14 +80,15 @@ class SessionItem @AssistedInject constructor(
                         actionSessionToSessionDetail(
                             session.id,
                             TRANSITION_NAME_SUFFIX,
-                            searchQuery),
+                            searchQuery
+                        ),
                         extra
                     )
             }
             itemRoot.transitionName = "${session.id}-$TRANSITION_NAME_SUFFIX"
             live.isVisible = session.isOnGoing
             bindSessionMessage(session, viewBinding)
-            title.text = session.title.getByLang(defaultLang())
+            title.text = session.title.currentLangString
             title.setSearchHighlight()
             room.text = session.minutesRoom(defaultLang())
             imageRequestDisposables.clear()
@@ -169,7 +170,8 @@ class SessionItem @AssistedInject constructor(
                     actionSessionToSpeaker(
                         speaker.id,
                         TRANSITION_NAME_SUFFIX,
-                        null),
+                        null
+                    ),
                     extras
                 )
             }
@@ -217,7 +219,8 @@ class SessionItem @AssistedInject constructor(
                 BackgroundColorSpan(highlightColor),
                 matcher.start(),
                 matcher.end(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
         }
         text = spannableStringBuilder
     }


### PR DESCRIPTION
## Issue
none

## Overview (Required)
Fixed a bug that the session title was not translated even if set english lang to device.

## Links
none

## Screenshot
| Before | After
| :--: | :--:
| <img src="https://user-images.githubusercontent.com/33515193/74395475-c2c1ff80-4e52-11ea-9be7-9d9e8484fc9c.png" width="320" /> | <img src="https://user-images.githubusercontent.com/33515193/74395460-b50c7a00-4e52-11ea-97c7-9f4fa6d95667.png" width="320" />