### PR TITLE
[iOS]Change call location of loadMap() 

### DIFF
--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -18,11 +18,11 @@ final class FloorMapViewController: ContentViewController {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         title = L10n.floorMaps
-        loadMap()
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        loadMap()
     }
 }
 

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -19,7 +19,7 @@ final class FloorMapViewController: ContentViewController {
         super.init(coder: coder)
         title = L10n.floorMaps
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         loadMap()


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- `viewDidLoad()` method that must be called in A was called in `init()` , so it was fixed
  - Before the fix,  `Thread 1: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value `  [occurred in the following parts:](https://github.com/DroidKaigi/conference-app-2020/pull/773/files#diff-4bb5ebce785a29b29305cf99ad3c3338R33-R34)

```Swift

let width = imageView.image?.size.width
let height = imageView.image?.size.height
```

## Links
None

## Screenshot
No UI changes.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/28621480/74233804-bf256000-4d0e-11ea-8c40-d24daedd90e8.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/28621480/74233804-bf256000-4d0e-11ea-8c40-d24daedd90e8.PNG" width="300" />
