### PR TITLE
[iOS]Cache images when loading floor map

### DIFF
--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -33,8 +33,8 @@ private extension FloorMapViewController {
     /// This method caches the floor map image in LRU memory when loading from server.
     func loadMap() {
         // Configure cache
-        ImageCache.shared.costLimit = 1024 * 1024 * 100 // 100 MB
-        ImageCache.shared.countLimit = 100
+        ImageCache.shared.costLimit = 1024 * 1024 * 5 // 5 MB
+        ImageCache.shared.countLimit = 10
         ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
         
         ImageLoadingOptions.shared.failureImage = UIImage(named: "map") // The set image is applied when reading from the server fails

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -32,8 +32,8 @@ private extension FloorMapViewController {
     /// This method caches the floor map image in LRU memory when loading from server.
     func loadMap() {
         // Configure cache
-        ImageCache.shared.costLimit = 1024 * 1024 * 5 // 5 MB
-        ImageCache.shared.countLimit = 10
+        ImageCache.shared.costLimit = 1024 * 1024 * 50 // 50 MB
+        ImageCache.shared.countLimit = 50
         ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
 
         ImageLoadingOptions.shared.failureImage = Asset.map.image // The set image is applied when reading from the server fails

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -29,19 +29,39 @@ final class FloorMapViewController: ContentViewController {
 // MARK: - Private functions
 
 private extension FloorMapViewController {
+    
+    /// This method caches the floor map image in LRU memory when loading from server.
     func loadMap() {
-        let width = imageView.image?.size.width
-        let height = imageView.image?.size.height
-
+        // Configure cache
+        ImageCache.shared.costLimit = 1024 * 1024 * 100 // 100 MB
+        ImageCache.shared.countLimit = 100
+        ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
+        
+        ImageLoadingOptions.shared.failureImage = UIImage(named: "map") // The set image is applied when reading from the server fails
+        
         let urlString: String = "https://api.droidkaigi.jp/images/2020/map.png"
         if let url = URL(string: urlString) {
+            let width = imageView.image?.size.width
+            let height = imageView.image?.size.height
+            
             let request = ImageRequest(
                 url: url,
                 processors: [ImageProcessor.Resize(size: CGSize(width: width!, height: height!))] // Set target size in pixels
             )
-            let options = ImageLoadingOptions(
-                failureImage: UIImage(named: "map")) // The set image is applied when reading from the server fails
-            Nuke.loadImage(with: request, options: options, into: imageView)
+            
+            if ImageCache.shared[request] !=  nil {
+                self.imageView.image = ImageCache.shared[request]
+            } else {
+                ImagePipeline.shared.loadImage(with: url) { result in
+                    switch result {
+                        case let .success(response):
+                            ImageCache.shared[request] = response.image // Set cache
+                            self.imageView.image = ImageCache.shared[request]
+                        case .failure:
+                            self.imageView.image = ImageLoadingOptions.shared.failureImage
+                    }
+                }
+            }
         }
     }
 }

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -19,7 +19,7 @@ final class FloorMapViewController: ContentViewController {
         super.init(coder: coder)
         title = L10n.floorMaps
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         loadMap()
@@ -29,36 +29,35 @@ final class FloorMapViewController: ContentViewController {
 // MARK: - Private functions
 
 private extension FloorMapViewController {
-    
     /// This method caches the floor map image in LRU memory when loading from server.
     func loadMap() {
         // Configure cache
         ImageCache.shared.costLimit = 1024 * 1024 * 5 // 5 MB
         ImageCache.shared.countLimit = 10
         ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
-        
-        ImageLoadingOptions.shared.failureImage = UIImage(named: "map") // The set image is applied when reading from the server fails
-        
+
+        ImageLoadingOptions.shared.failureImage = Asset.map.image // The set image is applied when reading from the server fails
+
         let urlString: String = "https://api.droidkaigi.jp/images/2020/map.png"
         if let url = URL(string: urlString) {
             let width = imageView.image?.size.width
             let height = imageView.image?.size.height
-            
+
             let request = ImageRequest(
                 url: url,
                 processors: [ImageProcessor.Resize(size: CGSize(width: width!, height: height!))] // Set target size in pixels
             )
-            
-            if ImageCache.shared[request] !=  nil {
-                self.imageView.image = ImageCache.shared[request]
+
+            if let cachedImage = ImageCache.shared[request] {
+                imageView.image = cachedImage
             } else {
                 ImagePipeline.shared.loadImage(with: url) { result in
                     switch result {
-                        case let .success(response):
-                            ImageCache.shared[request] = response.image // Set cache
-                            self.imageView.image = ImageCache.shared[request]
-                        case .failure:
-                            self.imageView.image = ImageLoadingOptions.shared.failureImage
+                    case let .success(response):
+                        ImageCache.shared[request] = response.image // Set cache
+                        self.imageView.image = ImageCache.shared[request]
+                    case .failure:
+                        self.imageView.image = ImageLoadingOptions.shared.failureImage
                     }
                 }
             }


### PR DESCRIPTION
## Issue
- close #770

## Overview (Required)
- Cache images when loading floor map

## Links
- [Nuke - LRU Memory Cache](https://github.com/kean/Nuke/tree/master#lru-memory-cache)

## Screenshot
No UI changes.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/28621480/74233804-bf256000-4d0e-11ea-8c40-d24daedd90e8.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/28621480/74233804-bf256000-4d0e-11ea-8c40-d24daedd90e8.PNG" width="300" />
