### PR TITLE
[iOS] Expand collection/tableview bottom edge to superview beyond safe area

### DIFF
--- a/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsViewController.xib
+++ b/ios-base/DroidKaigi 2020/Announcements/Views/AnnouncementsViewController.xib
@@ -20,15 +20,15 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="WIp-LM-x6u">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                 </tableView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="WIp-LM-x6u" secondAttribute="trailing" id="G9U-Ah-osY"/>
-                <constraint firstItem="WIp-LM-x6u" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" symbolic="YES" id="YVX-7K-KLE"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="WIp-LM-x6u" secondAttribute="bottom" id="lZL-21-9I6"/>
+                <constraint firstItem="WIp-LM-x6u" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" symbolic="YES" id="YVX-7K-KLE"/>
+                <constraint firstAttribute="bottom" secondItem="WIp-LM-x6u" secondAttribute="bottom" id="lZL-21-9I6"/>
                 <constraint firstItem="WIp-LM-x6u" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="tUo-OX-nt5"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/ios-base/DroidKaigi 2020/Session/Views/SessionViewController.xib
+++ b/ios-base/DroidKaigi 2020/Session/Views/SessionViewController.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -56,7 +57,7 @@
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Hsf-NN-TUk">
-                    <rect key="frame" x="0.0" y="63" width="414" height="799"/>
+                    <rect key="frame" x="0.0" y="63" width="414" height="833"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="heg-Pr-lpV">
                         <size key="itemSize" width="50" height="50"/>
@@ -73,7 +74,7 @@
                 <constraint firstItem="Hsf-NN-TUk" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="dDc-fc-RRi"/>
                 <constraint firstAttribute="trailing" secondItem="5o3-uR-6fq" secondAttribute="trailing" id="dsH-gm-RZ6"/>
                 <constraint firstAttribute="top" secondItem="5o3-uR-6fq" secondAttribute="top" id="lYQ-d1-gen"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="Hsf-NN-TUk" secondAttribute="bottom" id="orM-gx-LxE"/>
+                <constraint firstAttribute="bottom" secondItem="Hsf-NN-TUk" secondAttribute="bottom" id="orM-gx-LxE"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Hsf-NN-TUk" secondAttribute="trailing" id="u7u-zd-Dsu"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
## Issue
- unissued.

## Overview (Required)
- Expand collection/tableview bottom edge to superview beyond safe area.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/29206446/74445008-0a7b7200-4eb9-11ea-9eaa-db7c9b300890.png" width="300" /> | <img src="https://user-images.githubusercontent.com/29206446/74444999-08191800-4eb9-11ea-8bc2-34681e00e1b2.png" width="300" />
<img src="https://user-images.githubusercontent.com/29206446/74445003-094a4500-4eb9-11ea-9956-5dd0a7e310b8.png" width="300" /> | <img src="https://user-images.githubusercontent.com/29206446/74444993-03ecfa80-4eb9-11ea-9f2a-29e8f64af31a.png" width="300" />
