### PR TITLE
Fix bottom bar wrong position when reattached

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2020/session/ui/item/SessionDetailDescriptionItem.kt
@@ -37,7 +37,8 @@ class SessionDetailDescriptionItem @AssistedInject constructor(
     override fun getLayout() = R.layout.item_session_detail_description
 
     override fun bind(binding: ItemSessionDetailDescriptionBinding, position: Int) {
-        val fullDescription = session.desc
+        // FIXME: When session description is empty and back from the floor map, the layout is broken without this.
+        val fullDescription = if (session.desc.isEmpty()) "\n" else session.desc
         val textView = binding.sessionDescription
         textView.doOnPreDraw {
             textView.text = fullDescription


### PR DESCRIPTION
## Issue
- N/A

## Overview (Required)
- When open session detail screen and go to floor map by bottom app's menu, bottom app position is shifted.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/27717556/74589834-40049480-504c-11ea-92dc-34746a6d4465.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/27717556/74589833-3b3fe080-504c-11ea-9923-da5464d02780.gif" width="300" />