### PR TITLE
Fix Speech Session message if favorited

### DIFF
--- a/ios-base/DroidKaigi 2020/Session/Models/BookingSessionProvider.swift
+++ b/ios-base/DroidKaigi 2020/Session/Models/BookingSessionProvider.swift
@@ -4,6 +4,16 @@ import RxRealm
 import RxSwift
 
 final class BookingSessionProvider {
+    init() {
+        let config = Realm.Configuration(
+            schemaVersion: 1,
+            migrationBlock: { _, oldSchemaVersion in
+                if oldSchemaVersion < 1 {}
+            }
+        )
+        Realm.Configuration.defaultConfiguration = config
+    }
+
     func bookSession(_ session: Session) {
         do {
             let realm = try Realm()

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/Mapper/RealmToModelMapper.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/Mapper/RealmToModelMapper.swift
@@ -73,7 +73,10 @@ final class RealmToModelMapper {
                 isInterpretationTarget: session.isInterpretationTarget,
                 isFavorited: session.isFavorited,
                 speakers: session.speakers.map { toModel(speakerEntity: $0) },
-                message: nil
+                message: LocaledString(
+                    ja: session.message ?? "",
+                    en: session.enMessage ?? ""
+                )
             )
         }
     }

--- a/ios-base/DroidKaigi 2020/Session/RealmEntity/SessionEntity.swift
+++ b/ios-base/DroidKaigi 2020/Session/RealmEntity/SessionEntity.swift
@@ -21,6 +21,8 @@ final class SessionEntity: Object {
     @objc dynamic var isFavorited: Bool = false
 
     let speakers: List<SpeakerEntity>
+    @objc dynamic var message: String?
+    @objc dynamic var enMessage: String?
 
     init(session: Session) {
         let sessionTypeIds: [(String, SessionType)] = [
@@ -56,6 +58,8 @@ final class SessionEntity: Object {
             let speakers: List<SpeakerEntity> = List()
             speakers.append(objectsIn: speech.speakers.map { SpeakerEntity(speaker: $0) })
             self.speakers = speakers
+            message = speech.message?.ja
+            enMessage = speech.message?.en
         } else if let service = session as? ServiceSession {
             sessionType = sessionTypeIds.first(where: { $0.1 == service.sessionType })?.0
             speakers = .init()


### PR DESCRIPTION
## Issue
- close #782 
  - Thank you for your reporting, @nukka123!

## Overview (Required)
- Add message member in SessionEntity.
- Add mapper function that maps message valuable in SessionEntity to SpeechSession.
- Add Realm migration behavior that in conjunction scheme version like the Android version app because of error message like `Binding error to behavior relay: Error Domain=io.realm Code=10 "Migration is required due to the following errors:`.
  - Because of that, if the session favorited in the previous version, the upgraded version's session message is temporarily blank. To fix it, re-favoriting the session.

## Links
- Nothing

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6965122/74593829-e06daf80-5072-11ea-801e-c34ab2e60c75.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6965122/74593840-eebbcb80-5072-11ea-9d4a-3e3d603cdc32.png" width="300" />
