### PR TITLE
#785 Fix to use https connection

### DIFF
--- a/android-base/src/main/AndroidManifest.xml
+++ b/android-base/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="false"
-        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.DroidKaigi.DayNight">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -111,13 +111,13 @@ kotlin {
 
 android {
     defaultConfig {
-        buildConfigField "String", "API_ENDPOINT", "\"http://deploy-preview-49--droidkaigi-api-dev.netlify.com/2020\""
+        buildConfigField "String", "API_ENDPOINT", "\"https://deploy-preview-49--droidkaigi-api-dev.netlify.com/2020\""
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "API_ENDPOINT", "\"http://api.droidkaigi.jp/2020\""
+            buildConfigField "String", "API_ENDPOINT", "\"https://api.droidkaigi.jp/2020\""
         }
     }
 }

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/KtorDroidKaigiApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/KtorDroidKaigiApi.kt
@@ -37,7 +37,7 @@ internal open class KtorDroidKaigiApi constructor(
     override suspend fun getSessions(): Response {
         // We are separate getting response string and parsing for Kotlin Native
         val rawResponse = httpClient.get<String> {
-            url("$apiEndpoint/timetable")
+            url("$apiEndpoint/timetable/")
             accept(ContentType.Application.Json)
         }
         return json.parse(ResponseImpl.serializer(), rawResponse)

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/KtorDroidKaigiApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2020/data/api/internal/KtorDroidKaigiApi.kt
@@ -84,7 +84,7 @@ internal open class KtorDroidKaigiApi constructor(
 
     override suspend fun getAnnouncements(lang: LangParameter): AnnouncementListResponse {
         val rawResponse = httpClient.get<String> {
-            url("$apiEndpoint/announcements/${lang.value}")
+            url("$apiEndpoint/announcements/${lang.value}/")
             accept(ContentType.Application.Json)
         }
 
@@ -93,7 +93,7 @@ internal open class KtorDroidKaigiApi constructor(
 
     override suspend fun getSponsors(): SponsorListResponse {
         val rawResponse = httpClient.get<String> {
-            url("$apiEndpoint/sponsors")
+            url("$apiEndpoint/sponsors/")
             accept(ContentType.Application.Json)
         }
 
@@ -116,7 +116,7 @@ internal open class KtorDroidKaigiApi constructor(
 
     override suspend fun getStaffs(): StaffResponse {
         val rawResponse = httpClient.get<String> {
-            url("$apiEndpoint/committee_members")
+            url("$apiEndpoint/committee_members/")
             accept(ContentType.Application.Json)
         }
 
@@ -139,7 +139,7 @@ internal open class KtorDroidKaigiApi constructor(
 
     override suspend fun getContributorList(): ContributorResponse {
         val rawResponse = httpClient.get<String> {
-            url("$apiEndpoint/contributors")
+            url("$apiEndpoint/contributors/")
             accept(ContentType.Application.Json)
         }
 

--- a/data/api/src/iosMain/kotlinDebug/io/github/droidkaigi/confsched2020/data/api/internal/apiEndpoint.kt
+++ b/data/api/src/iosMain/kotlinDebug/io/github/droidkaigi/confsched2020/data/api/internal/apiEndpoint.kt
@@ -1,5 +1,5 @@
 package io.github.droidkaigi.confsched2020.data.api.internal
 
 internal actual fun apiEndpoint(): String {
-    return "http://deploy-preview-49--droidkaigi-api-dev.netlify.com/2020"
+    return "https://deploy-preview-49--droidkaigi-api-dev.netlify.com/2020"
 }

--- a/data/api/src/iosMain/kotlinRelease/io/github/droidkaigi/confsched2020/data/api/internal/apiEndpoint.kt
+++ b/data/api/src/iosMain/kotlinRelease/io/github/droidkaigi/confsched2020/data/api/internal/apiEndpoint.kt
@@ -1,3 +1,3 @@
 package io.github.droidkaigi.confsched2020.data.api.internal
 
-internal actual fun apiEndpoint(): String = "http://api.droidkaigi.jp/2020"
+internal actual fun apiEndpoint(): String = "https://api.droidkaigi.jp/2020"


### PR DESCRIPTION
## Issue
- close #785 

## Overview (Required)
- API_ENDPOINT change scheme from http to https
- adding last `/` to timetable api URL.
- delete `usesCleartextTraffic`

## Others
- marge target branch is `master` ok?