### PR TITLE
[iOS] Fix error if build directory is already exists

### DIFF
--- a/ios-base/scripts/build_kotlin_modules.sh
+++ b/ios-base/scripts/build_kotlin_modules.sh
@@ -2,5 +2,5 @@
 
  cd $SRCROOT/../
  BUILD_IOS=true ./gradlew :ioscombined:$KN_LIBRARY_BUILD_TASK -PXCODE_CONFIGURATION=${CONFIGURATION}
- mkdir $SRCROOT/build
+ mkdir -p $SRCROOT/build
  cp -r $KN_LIBRARY_BUILD_PATH $SRCROOT/build


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Fix error of `mkdir $SRCROOT/build` if build directory is already exists
```
mkdir: /Users/.../conference-app-2020/ios-base/build: File exists
```
## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
