### PR TITLE
[iOS] Cache speaker icon's image

### DIFF
--- a/ios-base/DroidKaigi 2020/AppDelegate.swift
+++ b/ios-base/DroidKaigi 2020/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Material
+import Nuke
 import UIKit
 
 @UIApplicationMain
@@ -23,6 +24,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             window.rootViewController = root
             self.window = window
             self.window?.makeKeyAndVisible()
+
+            // Configure cache
+            ImageCache.shared.costLimit = 1024 * 1024 * 50 // 50 MB
+            ImageCache.shared.countLimit = 100
+            ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
         }
 
         return true

--- a/ios-base/DroidKaigi 2020/Extentions/UIApplication+Ex.swift
+++ b/ios-base/DroidKaigi 2020/Extentions/UIApplication+Ex.swift
@@ -1,6 +1,5 @@
-
-import UIKit
 import Material
+import UIKit
 
 extension UIApplication {
     class func topViewController(controller: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {

--- a/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
+++ b/ios-base/DroidKaigi 2020/FloorMap/FloorMapViewController.swift
@@ -31,13 +31,6 @@ final class FloorMapViewController: ContentViewController {
 private extension FloorMapViewController {
     /// This method caches the floor map image in LRU memory when loading from server.
     func loadMap() {
-        // Configure cache
-        ImageCache.shared.costLimit = 1024 * 1024 * 50 // 50 MB
-        ImageCache.shared.countLimit = 50
-        ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
-
-        ImageLoadingOptions.shared.failureImage = Asset.map.image // The set image is applied when reading from the server fails
-
         let urlString: String = "https://api.droidkaigi.jp/images/2020/map.png"
         if let url = URL(string: urlString) {
             let width = imageView.image?.size.width
@@ -57,7 +50,7 @@ private extension FloorMapViewController {
                         ImageCache.shared[request] = response.image // Set cache
                         self.imageView.image = ImageCache.shared[request]
                     case .failure:
-                        self.imageView.image = ImageLoadingOptions.shared.failureImage
+                        self.imageView.image = Asset.map.image // The set image is applied when reading from the server fails
                     }
                 }
             }

--- a/ios-base/DroidKaigi 2020/SceneDelegate.swift
+++ b/ios-base/DroidKaigi 2020/SceneDelegate.swift
@@ -1,4 +1,5 @@
 import Material
+import Nuke
 import UIKit
 
 @available(iOS 13.0, *)
@@ -25,6 +26,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = root
         self.window = window
         self.window?.makeKeyAndVisible()
+        
+        // Configure cache
+        ImageCache.shared.costLimit = 1024 * 1024 * 50 // 50 MB
+        ImageCache.shared.countLimit = 100
+        ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
@@ -81,12 +81,10 @@ final class SessionCell: UICollectionViewCell {
             ImageCache.shared.countLimit = 100
             ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
 
-            ImageLoadingOptions.shared.transition = .fadeIn(duration: 0.3)
-            
             let request = ImageRequest(
                 url: imageURL
             )
-            
+
             if let cachedImage = ImageCache.shared[request] {
                 speakerIconView.image = cachedImage
             } else {

--- a/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
@@ -76,11 +76,6 @@ final class SessionCell: UICollectionViewCell {
         let view = UIControl()
         let speakerIconView = UIImageView()
         if let imageURL = imageURL {
-            // Configure cache
-            ImageCache.shared.costLimit = 1024 * 1024 * 50 // 50 MB
-            ImageCache.shared.countLimit = 100
-            ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
-
             let request = ImageRequest(
                 url: imageURL
             )

--- a/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
@@ -92,7 +92,11 @@ final class SessionCell: UICollectionViewCell {
                     switch result {
                     case let .success(response):
                         ImageCache.shared[request] = response.image // Set cache
-                        speakerIconView.image = ImageCache.shared[request]
+                        UIView.transition(with: speakerIconView,
+                                          duration: 0.3,
+                                          options: .transitionCrossDissolve,
+                                          animations: { speakerIconView.image = ImageCache.shared[request] },
+                                          completion: nil)
                     case .failure:
                         speakerIconView.backgroundColor = UIColor.white
                     }

--- a/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
+++ b/ios-base/DroidKaigi 2020/Session/Views/Cells/SessionCell.swift
@@ -81,7 +81,6 @@ final class SessionCell: UICollectionViewCell {
             ImageCache.shared.countLimit = 100
             ImageCache.shared.ttl = 120 // Invalidate image after 120 sec
 
-            ImageLoadingOptions.shared.failureImage = Asset.logo.image // The set image is applied when reading from the server fails
             ImageLoadingOptions.shared.transition = .fadeIn(duration: 0.3)
             
             let request = ImageRequest(
@@ -97,7 +96,7 @@ final class SessionCell: UICollectionViewCell {
                         ImageCache.shared[request] = response.image // Set cache
                         speakerIconView.image = ImageCache.shared[request]
                     case .failure:
-                        speakerIconView.image = ImageLoadingOptions.shared.failureImage
+                        speakerIconView.backgroundColor = UIColor.white
                     }
                 }
             }


### PR DESCRIPTION
## Issue
- close #778

## Overview (Required)
- Cache speaker icon's image on timeline

## Links
- [Nuke - LRU Memory Cache](https://github.com/kean/Nuke/tree/master#lru-memory-cache)

## Screenshot
No UI changes.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/28621480/74746593-067c9500-52a9-11ea-91ee-e816c10b6f3e.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/28621480/74746593-067c9500-52a9-11ea-91ee-e816c10b6f3e.PNG" width="300" />
