### PR TITLE
Update Navigation 2.3.0-alpha03

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,6 @@ allprojects {
         google()
         jcenter()
 
-        maven {
-            // https://issuetracker.google.com/issues/148316337#comment5
-            url "https://ci.android.com/builds/submitted/6167672/androidx_snapshot/latest/repository/"
-        }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         maven { url "https://dl.bintray.com/soywiz/soywiz" }

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -66,12 +66,11 @@ object Dep {
         }
 
         object Navigation {
-            val version = "2.2.1"
+            val version = "2.3.0-alpha03"
             val runtimeKtx = "androidx.navigation:navigation-runtime-ktx:$version"
             val fragmentKtx = "androidx.navigation:navigation-fragment-ktx:$version"
-            val uiKtx = "androidx.navigation:navigation-ui-ktx:$version"
-            val dynamicFeaturesFragment = "androidx.navigation:navigation-dynamic-features-fragment:2.3.0-SNAPSHOT"
-            val dynamicFeaturesRuntime = "androidx.navigation:navigation-dynamic-features-runtime:2.3.0-SNAPSHOT"
+            val uiKtx = "androidx.navigation:navigation-ui-ktx:2.3.0-alpha03"
+            val dynamicFeaturesFragment = "androidx.navigation:navigation-dynamic-features-fragment:$version"
         }
 
         object Work {

--- a/corecomponent/androidcomponent/build.gradle
+++ b/corecomponent/androidcomponent/build.gradle
@@ -31,12 +31,7 @@ dependencies {
     api Dep.AndroidX.Navigation.uiKtx
 
     api Dep.Play.core
-    api(Dep.AndroidX.Navigation.dynamicFeaturesFragment) {
-        transitive = false
-    }
-    api(Dep.AndroidX.Navigation.dynamicFeaturesRuntime) {
-        transitive = false
-    }
+    api Dep.AndroidX.Navigation.dynamicFeaturesFragment
 
     implementation Dep.Ktor.clientAndroid
     implementation Dep.Firebase.firestoreKtx


### PR DESCRIPTION
## Overview (Required)
- Update Navigation 2.3.0-alpha03
- Now, SNAPSHOT repository is not working.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
