### PR TITLE
Update oss-license-plugin to list more libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - checkout
       - restore_and_save_gradle_cache
-      - run: ./gradlew android-base:assembleDebug --offline
+      - run: ./gradlew android-base:assembleDebug
       - store_artifacts:
           path: android-base/build/outputs
       - run: .circleci/android/deploy-to-deploygate.bash

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -10,7 +10,7 @@ object Dep {
         val safeArgs =
             "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0-alpha03"
         val jetifier = "com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta05"
-        val licensesPlugin = "com.google.android.gms:oss-licenses-plugin:0.10.0"
+        val licensesPlugin = "com.google.android.gms:oss-licenses-plugin:0.10.2"
         val crashlytics = "com.google.firebase:firebase-crashlytics-gradle:2.0.0-beta01"
         val iconRibbonPlugin = "com.akaita.android:easylauncher:1.3.1"
         val gradleVersionsPlugin = "com.github.ben-manes:gradle-versions-plugin:0.22.0"


### PR DESCRIPTION
## Issue
- close #713

## Overview (Required)
- Update OSS licenses Gradle plugin 
  - More libraries are listed than before!

## Links
- <https://developers.google.com/android/guides/releases#march_09_2020>

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/17231507/76621608-25eaa300-6573-11ea-93b8-8d355e2b637c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/17231507/76621912-c771f480-6573-11ea-8c55-f79bd634ac6f.png" width="300" />
